### PR TITLE
Handle MultiJson ParseErrors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in shoulda-matchers-json.gemspec
 gemspec
+gem 'ctags'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in shoulda-matchers-json.gemspec
 gemspec
-gem 'ctags'

--- a/lib/json_matchers/matcher.rb
+++ b/lib/json_matchers/matcher.rb
@@ -24,6 +24,8 @@ module JsonMatchers
       false
     rescue JSON::ParserError
       raise InvalidSchemaError
+    rescue MultiJson::ParseError
+      raise InvalidSchemaError
     end
 
     def validation_failure_message


### PR DESCRIPTION
Previously, the first rspec test was failing because the matcher.rb was only rescuing JSON::ParseErrors but not MultiJson::ParseErrors. For whatever reason, the empty string raised the latter, not the former, error. 

With this minor fix, all tests are green.