### PR TITLE
Replace rspec-rails dependency with rspec

### DIFF
--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec-rails", ">= 2.0"
+  spec.add_development_dependency "rspec", ">= 2.0"
 end


### PR DESCRIPTION
* Ensure compatibility with non-Rails projects by replacing `rspec-rails`
  dependency with `rspec`