### PR TITLE
`strict: false` when `"required"` key absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Pass `strict: false` when the `"required"` key is present in the Schema.
+
 0.4.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ describe "GET /posts" do
 end
 ```
 
+Unless specified, the validator will be configured with `strict: false`
+when the schema contains a `"required"` key, and `true` otherwise.
+
 A list of available options can be found [here][options]
 
 [options]: https://github.com/ruby-json-schema/json-schema/blob/2.2.4/lib/json-schema/validator.rb#L160-L162

--- a/lib/json_matchers/matcher.rb
+++ b/lib/json_matchers/matcher.rb
@@ -11,7 +11,7 @@ module JsonMatchers
       @response = response
 
       validator_options = {
-        strict: true,
+        strict: required_key_absent?,
       }.merge(options)
 
       JSON::Validator.validate!(
@@ -33,5 +33,13 @@ module JsonMatchers
     private
 
     attr_reader :schema_path, :options
+
+    def schema
+      @schema ||= schema_path.read
+    end
+
+    def required_key_absent?
+      !schema.include?(%{"required":})
+    end
   end
 end

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -113,4 +113,66 @@ describe JsonMatchers, "#match_response_schema" do
     expect(valid_response).to match_response_schema("collection")
     expect(invalid_response).not_to match_response_schema("collection")
   end
+
+  context "when the `required` key is absent" do
+    it "validates with `strict: true`" do
+      create_schema("without_additional", {
+        "type" => "object",
+        "properties" => {
+          "foo" => { "type" => "string" },
+        },
+      })
+      create_schema("with_additional", {
+        "type" => "object",
+        "properties" => {
+          "foo" => { "type" => "string" },
+        },
+        "additionalProperties" => [
+          "bar" => { "type" => "string" },
+        ],
+      })
+
+      response = response_for(
+        "foo" => "is required",
+        "bar" => "is additional",
+      )
+
+      expect(response).not_to match_response_schema("without_additional")
+      expect(response).to match_response_schema("with_additional")
+    end
+  end
+
+  context "when the `required` key is present" do
+    it "validates with `strict: false`" do
+      create_schema("without_additional", {
+        "type" => "object",
+        "required" => [
+          "foo",
+        ],
+        "properties" => {
+          "foo" => { "type" => "string" },
+        },
+      })
+      create_schema("with_additional", {
+        "type" => "object",
+        "required" => [
+          "foo",
+        ],
+        "properties" => {
+          "foo" => { "type" => "string" },
+        },
+        "additionalProperties" => [
+          "bar" => { "type" => "string" },
+        ],
+      })
+
+      response = response_for(
+        "foo" => "is required",
+        "bar" => "is additional",
+      )
+
+      expect(response).to match_response_schema("without_additional")
+      expect(response).to match_response_schema("with_additional")
+    end
+  end
 end


### PR DESCRIPTION
Inspired by [#9], [#26], and [#27].

Closes [#26] and [#27].

From the [ruby-json-schema/json-schema][README]:

> With the `:strict` option, validation fails when an object contains
> properties that are not defined in the schema’s property list or
> doesn’t match the `additionalProperties` property.
> Furthermore, **all properties are treated as `required` regardless of
> required properties set in the schema.**

In other words, when evaluating with `strict: true`, the `required`
keyword is ignored.

This commit detects the `required` keyword, and sets `strict: false`
when present.

[#9]: https://github.com/thoughtbot/json_matchers/issues/9
[#26]: https://github.com/thoughtbot/json_matchers/issues/26
[#27]: https://github.com/thoughtbot/json_matchers/issues/27
[README]: https://github.com/ruby-json-schema/json-schema#strictly-validate-an-objects-properties