### PR TITLE
Default to `strict: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* No longer default to `strict: true`.
+
 0.4.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ end
 
 ### Passing options to the validator
 
-The matcher accepts options, which it'll pass to the validator:
+The matcher accepts options, which it passes to the validator:
 
 ```ruby
 # spec/requests/posts_spec.rb
@@ -83,7 +83,7 @@ describe "GET /posts" do
     get posts_path, format: :json
 
     expect(response.status).to eq 200
-    expect(response).to match_response_schema("posts", strict: false)
+    expect(response).to match_response_schema("posts", strict: true)
   end
 end
 ```

--- a/lib/json_matchers/matcher.rb
+++ b/lib/json_matchers/matcher.rb
@@ -10,14 +10,10 @@ module JsonMatchers
     def matches?(response)
       @response = response
 
-      validator_options = {
-        strict: true,
-      }.merge(options)
-
       JSON::Validator.validate!(
         schema_path.to_s,
         response.body,
-        validator_options,
+        options,
       )
     rescue JSON::Schema::ValidationError => ex
       @validation_failure_message = ex.message


### PR DESCRIPTION
Inspired by [#9], [#26], and [#27].

Closes [#26] and [#27].

From the [ruby-json-schema/json-schema][README]:

> With the `:strict` option, validation fails when an object contains
> properties that are not defined in the schema’s property list or
> doesn’t match the `additionalProperties` property.
> Furthermore, **all properties are treated as `required` regardless of
> required properties set in the schema.**

In other words, when evaluating with `strict: true`, the `required`
keyword is ignored.

This commit removes the `strict: true` default override, falling back to
the underlying gem's default options.

[#9]: https://github.com/thoughtbot/json_matchers/issues/9
[#26]: https://github.com/thoughtbot/json_matchers/pull/26
[#27]: https://github.com/thoughtbot/json_matchers/pull/27
[README]: https://github.com/ruby-json-schema/json-schema#strictly-validate-an-objects-properties