### PR TITLE
Use json_schema instead of json-schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
 master
 ======
 
-* *Breaking Change* - remove support for configuring validation options.
+* *BREAKING CHANGE* Implement the validation with the `json_schema` gem instead
+  of `json-schema`. [#31]
+* *BREAKING CHANGE* - remove support for configuring validation options.
+
+[#31]: https://github.com/thoughtbot/json_matchers/pull/31
 
 0.9.0
 =====

--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("json-schema", "~> 2.7")
+  spec.add_dependency("json_schema")
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "pry"

--- a/lib/json_matchers.rb
+++ b/lib/json_matchers.rb
@@ -1,3 +1,4 @@
+require "pathname"
 require "json_matchers/version"
 require "json_matchers/matcher"
 require "json_matchers/errors"
@@ -8,6 +9,6 @@ module JsonMatchers
   end
 
   def self.path_to_schema(schema_name)
-    Pathname(schema_root).join("#{schema_name}.json")
+    Pathname.new(schema_root).join("#{schema_name}.json")
   end
 end

--- a/lib/json_matchers/assertion.rb
+++ b/lib/json_matchers/assertion.rb
@@ -14,7 +14,7 @@ module JsonMatchers
     def valid?(json)
       @payload = Payload.new(json)
 
-      matcher.matches?(payload.to_s)
+      matcher.matches?(payload)
     end
 
     def valid_failure_message
@@ -58,7 +58,7 @@ not to match schema "#{schema_name}":
     end
 
     def schema_body
-      File.read(schema_path)
+      schema_path.read
     end
 
     def format_json(json)

--- a/lib/json_matchers/parser.rb
+++ b/lib/json_matchers/parser.rb
@@ -1,0 +1,21 @@
+module JsonMatchers
+  class Parser
+    def initialize(schema_path)
+      @schema_path = schema_path
+    end
+
+    def parse
+      JsonSchema.parse!(schema_data)
+    rescue JSON::ParserError, JsonSchema::SchemaError => error
+      raise InvalidSchemaError.new(error)
+    end
+
+    private
+
+    attr_reader :schema_path
+
+    def schema_data
+      JSON.parse(schema_path.read)
+    end
+  end
+end

--- a/lib/json_matchers/payload.rb
+++ b/lib/json_matchers/payload.rb
@@ -4,6 +4,10 @@ module JsonMatchers
       @payload = extract_json_string(payload)
     end
 
+    def as_json
+      JSON.parse(payload)
+    end
+
     def to_s
       payload
     end

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -194,6 +194,24 @@ describe JsonMatchers, "#match_json_schema" do
     expect(json_as_array).not_to match_json_schema(schema)
   end
 
+  it "validates against a schema referencing with 'definitions'" do
+    schema = create(:schema, :referencing_definitions)
+
+    json = build(:response, :object)
+    json_as_hash = { "objects" => [json] }
+
+    expect(json_as_hash).to match_json_schema(schema)
+  end
+
+  it "fails against a schema referencing with 'definitions'" do
+    schema = create(:schema, :referencing_definitions)
+
+    json = build(:response, :invalid_object)
+    json_as_hash = { "objects" => [json] }
+
+    expect(json_as_hash).not_to match_json_schema(schema)
+  end
+
   def raise_error_containing(schema_or_body)
     raise_error do |error|
       sanitized_message = error.message.squish

--- a/spec/support/fake_response.rb
+++ b/spec/support/fake_response.rb
@@ -3,7 +3,7 @@ FakeResponse = Struct.new(:body) do
     JSON.parse(body)
   end
 
-  def to_json
+  def to_json(*)
     body
   end
 end

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -2,7 +2,6 @@ require "fileutils"
 
 module FileHelpers
   def setup_fixtures(*pathnames)
-    JSON::Validator.clear_cache
     original_schema_root = JsonMatchers.schema_root
 
     JsonMatchers.schema_root = File.join(*pathnames)

--- a/test/json_matchers/minitest/assertions_test.rb
+++ b/test/json_matchers/minitest/assertions_test.rb
@@ -163,6 +163,24 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
     refute_matches_json_schema(json_as_array, schema)
   end
 
+  test "validates against a schema referencing with 'definitions'" do
+    schema = create(:schema, :referencing_definitions)
+
+    json = build(:response, :object)
+    json_as_hash = { "objects" => [json] }
+
+    assert_matches_json_schema(json_as_hash, schema)
+  end
+
+  test "fails against a schema referencing with 'definitions'" do
+    schema = create(:schema, :referencing_definitions)
+
+    json = build(:response, :invalid_object)
+    json_as_hash = { "objects" => [json] }
+
+    refute_matches_json_schema(json_as_hash, schema)
+  end
+
   def assert_raises_error_containing(schema_or_body)
     raised_error = assert_raises(Minitest::Assertion) do
       yield


### PR DESCRIPTION
The problem
- `json_matchers` cannot easily be used concurrently with Heroku's JSON API tools, i.e. `prmd` and `committee`, because `json_matchers` makes different assumptions about the structure of the user's schemata. An example of an incompatibility can be found in https://github.com/thoughtbot/json_matchers/issues/25: `json_matchers` breaks when the `id` property is present within a schema, but the Heroku tools require the presence of the `id` property ([reference](https://github.com/interagent/prmd/blob/master/docs/schemata.md#meta-data)).
- This is happening because the libraries used to dereference JSON pointers behave differently. `json-schema`, the library we're currently using, appears to conform less strictly to the JSON Schema specification than the library the Heroku tools use, `json_schema`.

The solution
- One solution to this problem is to update `json_matchers` to use the same approach to validating schemata as the Heroku tools. This will require the following changes:
  1. Use `json_schema` instead of `json-schema` to validate schemata
  2. Update documentation to instruct readers to follow Heroku's
     guidelines for structuring schemata:
     https://github.com/interagent/prmd/blob/master/docs/schemata.md
  3. Update documentation to reflect that the `strict` option is no longer supported
- In this commit I've replaced `json-schema` with `json_schema` and updated the schemata fixtures in the specs. Per [this json_schema issue](https://github.com/brandur/json_schema/issues/22), in order to dereference JSON pointers referencing schemata in other files we need to access the gem's DocumentStore API directly. This is done in `Matcher#add_schemata_to_document_store`.
