### PR TITLE
Add ability to pass in response body as string

### DIFF
--- a/lib/json_matchers/matcher.rb
+++ b/lib/json_matchers/matcher.rb
@@ -8,9 +8,9 @@ module JsonMatchers
       elsif response.is_a?(String)
         response
       else
-        fail 'Response does not have a #body method and is ' \
-          'not a string. It has the class class ' \
-          "#{response.class}."
+        fail "Response does not have a #body method and is " \
+             "not a string. It has the class class " \
+             "#{response.class}."
       end
     end
 
@@ -23,7 +23,7 @@ module JsonMatchers
       JSON::Validator.validate!(
         schema_path.to_s,
         Matcher.extract_response_body(response),
-        options
+        options,
       )
     rescue JSON::Schema::ValidationError => ex
       @validation_failure_message = ex.message

--- a/lib/json_matchers/matcher.rb
+++ b/lib/json_matchers/matcher.rb
@@ -2,18 +2,28 @@ require "json-schema"
 
 module JsonMatchers
   class Matcher
+    def self.extract_response_body(response)
+      if response.respond_to?(:body)
+        response.body
+      elsif response.is_a?(String)
+        response
+      else
+        fail 'Response does not have a #body method and is ' \
+          'not a string. It has the class class ' \
+          "#{response.class}."
+      end
+    end
+
     def initialize(schema_path, **options)
       @schema_path = schema_path
       @options = options
     end
 
     def matches?(response)
-      @response = response
-
       JSON::Validator.validate!(
         schema_path.to_s,
-        response.body,
-        options,
+        Matcher.extract_response_body(response),
+        options
       )
     rescue JSON::Schema::ValidationError => ex
       @validation_failure_message = ex.message

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -14,7 +14,7 @@ module JsonMatchers
       <<-FAIL.strip_heredoc
       expected
 
-      #{response.body}
+      #{Matcher.extract_response_body(response)}
 
       to match schema "#{schema_name}":
 
@@ -31,7 +31,7 @@ module JsonMatchers
       <<-FAIL.strip_heredoc
       expected
 
-      #{response.body}
+      #{Matcher.extract_response_body(response)}
 
       not to match schema "#{schema_name}":
 

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -113,4 +113,21 @@ describe JsonMatchers, "#match_response_schema" do
     expect(valid_response).to match_response_schema("collection")
     expect(invalid_response).not_to match_response_schema("collection")
   end
+
+  it "works when a pure string is used for response" do
+    create_schema("foo_schema", {
+      "type" => "object",
+      "required" => [
+        "id",
+      ],
+      "properties" => {
+        "id" => { "type" => "number" },
+        "title" => {"type" => "string"},
+      },
+      "additionalProperties" => false,
+    })
+
+    expect({ "id" => 1, "title" => "bar" }.to_json).
+      to match_response_schema("foo_schema", strict: false)
+  end
 end

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -122,7 +122,7 @@ describe JsonMatchers, "#match_response_schema" do
       ],
       "properties" => {
         "id" => { "type" => "number" },
-        "title" => {"type" => "string"},
+        "title" => { "type" => "string" },
       },
       "additionalProperties" => false,
     })

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -19,7 +19,7 @@ module FileHelpers
                     else
                       json.to_json
                     end
-    double(body: response_body)
+    # double(body: response_body)
   end
 
   def schema_root

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -19,7 +19,7 @@ module FileHelpers
                     else
                       json.to_json
                     end
-    # double(body: response_body)
+    double(body: response_body)
   end
 
   def schema_root


### PR DESCRIPTION
Some libraries (like https://github.com/zipmark/rspec_api_documentation), do not give you direct access to the Response object. To allow for flexibility, give the user the ability to pass in a response as a string, as opposed to just and object that responds to #body.