### PR TITLE
Remove Rails dependencies

### DIFF
--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency("json-schema", "~> 2.6.0")
-  spec.add_dependency("activesupport", '>= 3.0.0')
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "pry"

--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec-rails", ">= 2.0"
+  spec.add_development_dependency "rspec", ">= 2.0"
 end

--- a/lib/json_matchers.rb
+++ b/lib/json_matchers.rb
@@ -1,7 +1,6 @@
 require "json_matchers/version"
 require "json_matchers/matcher"
 require "json_matchers/errors"
-require "active_support/all"
 
 module JsonMatchers
   @@schema_root = "#{Dir.pwd}/spec/support/api/schemas"

--- a/lib/json_matchers.rb
+++ b/lib/json_matchers.rb
@@ -4,9 +4,15 @@ require "json_matchers/errors"
 require "active_support/all"
 
 module JsonMatchers
-  mattr_accessor :schema_root
+  @@schema_root = "#{Dir.pwd}/spec/support/api/schemas"
 
-  self.schema_root = "#{Dir.pwd}/spec/support/api/schemas"
+  def self.schema_root
+    @@schema_root
+  end
+
+  def self.schema_root=(value)
+    @@schema_root = value
+  end
 
   def self.path_to_schema(schema_name)
     Pathname(schema_root).join("#{schema_name}.json")

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -1,3 +1,4 @@
+require "delegate"
 require "json_matchers"
 
 module JsonMatchers

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -58,7 +58,7 @@ module JsonMatchers
     def strip_heredoc(str)
       indent = str.scan(/^[ \t]*(?=\S)/).min
       indent = indent ? indent.size : 0
-      str.gsub(/^[ \t]{#{indent}}/, '')
+      str.gsub(/^[ \t]{#{indent}}/, "")
     end
   end
 end

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -12,7 +12,7 @@ module JsonMatchers
     end
 
     def failure_message(response)
-      <<-FAIL.strip_heredoc
+      strip_heredoc(<<-FAIL)
       expected
 
       #{response.body}
@@ -29,7 +29,7 @@ module JsonMatchers
     end
 
     def failure_message_when_negated(response)
-      <<-FAIL.strip_heredoc
+      strip_heredoc(<<-FAIL)
       expected
 
       #{response.body}
@@ -51,6 +51,14 @@ module JsonMatchers
 
     def schema_body
       File.read(schema_path)
+    end
+
+    private
+
+    def strip_heredoc(str)
+      indent = str.scan(/^[ \t]*(?=\S)/).min
+      indent = indent ? indent.size : 0
+      str.gsub(/^[ \t]{#{indent}}/, '')
     end
   end
 end


### PR DESCRIPTION
This PR replaces `rspec-rails` with `rspec`, and removes the `activesupport` dependency, which should make it easier to use this gem outside of a Rails environment. As a nice bonus, it also reduces the total number of gem dependencies (as reported by `bundle install`) from 35 to 15.

There were only 2 methods provided by ActiveSupport that were being used: `Module#mattr_accessor` and `String#strip_heredoc`. For `mattr_accessor`, I've added a (roughly) equivalent implementation, minus the instance-level getter and setter methods (which we presumably don't want anyway). As for `strip_heredoc`, I've just copied the implementation from ActiveSupport into a private method inside `JsonMatchers::RSpec`. Personally I'd de-indent the heredocs and live with the ugliness, but to each their own.

Anyway, thank you for writing this gem. I've used it in a bunch of projects when I needed to test my JSON APIs, and it's been hugely helpful :)