### PR TITLE
Format Failure Message JSON

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 master
 ======
 
+* Use `JSON.pretty_generate` to format error messages. [#44]
+
+[#44]: https://github.com/thoughtbot/json_matchers/pull/44
+
 0.6.0
 =====
 

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -12,36 +12,40 @@ module JsonMatchers
 
     def failure_message(response)
       <<-FAIL.strip_heredoc
-      expected
-
-      #{response.body}
-
-      to match schema "#{schema_name}":
-
-      #{schema_body}
+      #{validation_failure_message}
 
       ---
 
-      #{validation_failure_message}
+      expected
+
+      #{pretty_json(response.body)}
+
+      to match schema "#{schema_name}":
+
+      #{pretty_json(schema_body)}
 
       FAIL
     end
 
     def failure_message_when_negated(response)
       <<-FAIL.strip_heredoc
-      expected
-
-      #{response.body}
-
-      not to match schema "#{schema_name}":
-
-      #{schema_body}
+      #{validation_failure_message}
 
       ---
 
-      #{validation_failure_message}
+      expected
+
+      #{pretty_json(response.body)}
+
+      not to match schema "#{schema_name}":
+
+      #{pretty_json(schema_body)}
 
       FAIL
+    end
+
+    def pretty_json(json_string)
+      JSON.pretty_generate(JSON.parse(json_string.to_s))
     end
 
     def schema_path

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -72,7 +72,7 @@ describe JsonMatchers, "#match_response_schema" do
 
     expect {
       expect(response_for("bar" => 5)).to match_response_schema("foo")
-    }.to raise_error(/{"bar":5}/)
+    }.to raise_formatted_error(%{{ "bar": 5 }})
   end
 
   it "contains the body in the failure message when negated" do
@@ -80,7 +80,7 @@ describe JsonMatchers, "#match_response_schema" do
 
     expect {
       expect(response_for([])).not_to match_response_schema("foo")
-    }.to raise_error(/\[\]/)
+    }.to raise_formatted_error("[ ]")
   end
 
   it "contains the schema in the failure message" do
@@ -89,7 +89,7 @@ describe JsonMatchers, "#match_response_schema" do
 
     expect {
       expect(response_for("bar" => 5)).to match_response_schema("foo")
-    }.to raise_error(/#{schema.to_json}/)
+    }.to raise_formatted_error(%{{ "type": "array" }})
   end
 
   it "contains the schema in the failure message when negated" do
@@ -98,7 +98,7 @@ describe JsonMatchers, "#match_response_schema" do
 
     expect {
       expect(response_for([])).not_to match_response_schema("foo")
-    }.to raise_error(/#{schema.to_json}/)
+    }.to raise_formatted_error(%{{ "type": "array" }})
   end
 
   it "does not fail when the schema matches" do
@@ -128,5 +128,11 @@ describe JsonMatchers, "#match_response_schema" do
 
     expect(valid_response).to match_response_schema("collection")
     expect(invalid_response).not_to match_response_schema("collection")
+  end
+
+  def raise_formatted_error(error_message)
+    raise_error do |error|
+      expect(error.message.squish).to include(error_message)
+    end
   end
 end


### PR DESCRIPTION
This commit modifies the RSpec Matcher to use
[`JSON.pretty_generate`][docs] to improve the formatting of JSON bodies
and schemata that appear in failure messages.

Additionally, the `json-schema` provided error messages have been moved
to the top of the failure messages, so that the reasons for failure
appear above (potentially lengthy) JSON bodies.

[docs]: http://ruby-doc.org/stdlib-2.0.0/libdoc/json/rdoc/JSON.html#method-i-pretty_generate