### PR TITLE
Improve Failure Message Indentation

### DIFF
--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -11,35 +11,35 @@ module JsonMatchers
     end
 
     def failure_message(response)
-      <<-FAIL.strip_heredoc
-      #{validation_failure_message}
+      <<-FAIL
+#{validation_failure_message}
 
-      ---
+---
 
-      expected
+expected
 
-      #{pretty_json(response.body)}
+#{pretty_json(response.body)}
 
-      to match schema "#{schema_name}":
+to match schema "#{schema_name}":
 
-      #{pretty_json(schema_body)}
+#{pretty_json(schema_body)}
 
       FAIL
     end
 
     def failure_message_when_negated(response)
-      <<-FAIL.strip_heredoc
-      #{validation_failure_message}
+      <<-FAIL
+#{validation_failure_message}
 
-      ---
+---
 
-      expected
+expected
 
-      #{pretty_json(response.body)}
+#{pretty_json(response.body)}
 
-      not to match schema "#{schema_name}":
+not to match schema "#{schema_name}":
 
-      #{pretty_json(schema_body)}
+#{pretty_json(schema_body)}
 
       FAIL
     end


### PR DESCRIPTION
Unfortunately, [`String#strip_heredoc`][docs] isn't behaving as
expected.

`ruby@2.3` supports [stripping indentation from heredocs with the `~`
operator][string-literals], but this gem still supports older versions
of Ruby.

This commit left justifies all RSpec matcher failure messages as a
work around.

Examples are provided below.

[docs]: http://api.rubyonrails.org/classes/String.html#method-i-strip_heredoc
[string-literals]: https://ruby-doc.org/core-2.3.0/doc/syntax/literals_rdoc.html#label-Here+Documents

`<<-FAIL.strip_heredoc` (**before**)
---

```
     Failure/Error: expect(response_for([])).not_to match_response_schema("foo")

             ---

             expected

             [

       ]

             not to match schema "foo":

             {
         "type": "array"
       }
```

`<<~FAIL` (**ideal**)
---

```
     Failure/Error: expect(response_for([])).not_to match_response_schema("foo")

       ---

       expected

       [

       ]

       not to match schema "foo":

       {
         "type": "array"
       }

```

`<<-FAIL` with no indentation (**this commit**)

```
     Failure/Error: expect(response_for([])).not_to match_response_schema("foo")

       ---

       expected

       [

       ]

       not to match schema "foo":

       {
         "type": "array"
       }
```