### PR TITLE
Support configuring matcher default options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 master
 ======
 
+* Configure default options for all matchers.
 * Use `JSON.pretty_generate` to format error messages. [#44]
 
 [#44]: https://github.com/thoughtbot/json_matchers/pull/44

--- a/README.md
+++ b/README.md
@@ -103,7 +103,24 @@ describe "GET /posts" do
 end
 ```
 
-A list of available options can be found [here][options]
+A list of available options can be found [here][options].
+
+[options]: https://github.com/ruby-json-schema/json-schema/blob/2.2.4/lib/json-schema/validator.rb#L160-L162
+
+### Default matcher options
+
+To configure the default options passed to *all* matchers, call
+`JsonMatchers.configure`:
+
+```rb
+# spec/support/json_matchers.rb
+
+JsonMatchers.configure do |config|
+  config.options[:strict] = true
+end
+```
+
+A list of available options can be found [here][options].
 
 [options]: https://github.com/ruby-json-schema/json-schema/blob/2.2.4/lib/json-schema/validator.rb#L160-L162
 

--- a/lib/json_matchers.rb
+++ b/lib/json_matchers.rb
@@ -1,4 +1,5 @@
 require "json_matchers/version"
+require "json_matchers/configuration"
 require "json_matchers/matcher"
 require "json_matchers/errors"
 require "active_support/all"

--- a/lib/json_matchers/configuration.rb
+++ b/lib/json_matchers/configuration.rb
@@ -1,0 +1,17 @@
+module JsonMatchers
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+  class Configuration
+    attr_reader :options
+
+    def initialize
+      @options = {}
+    end
+  end
+end

--- a/lib/json_matchers/matcher.rb
+++ b/lib/json_matchers/matcher.rb
@@ -2,9 +2,9 @@ require "json-schema"
 
 module JsonMatchers
   class Matcher
-    def initialize(schema_path, **options)
+    def initialize(schema_path, options = {})
       @schema_path = schema_path
-      @options = options
+      @options = default_options.merge(options)
     end
 
     def matches?(response)
@@ -34,6 +34,10 @@ module JsonMatchers
       else
         response
       end
+    end
+
+    def default_options
+      JsonMatchers.configuration.options || {}
     end
   end
 end


### PR DESCRIPTION
Closes [#40].

To configure the default options passed to *all* matchers, call
`JsonMatchers.configure`:

```rb

JsonMatchers.configure do |config|
  config.options[:strict] = true
end
```

A list of available options can be found [here][options].

[#40]: https://github.com/thoughtbot/json_matchers/issues/40
[options]: https://github.com/ruby-json-schema/json-schema/blob/2.2.4/lib/json-schema/validator.rb#L160-L162