### PR TITLE
Remove Rails dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,17 @@
 master
 ======
 
+* Remove dependency on Rails. [#47]
+
+[#47]: https://github.com/thoughtbot/json_matchers/pull/47
+
 0.6.1
 =====
 
-* Configure default options for all matchers.
+* Configure default options for all matchers. [#46]
 * Use `JSON.pretty_generate` to format error messages. [#44]
 
+[#46]: https://github.com/thoughtbot/json_matchers/pull/46
 [#44]: https://github.com/thoughtbot/json_matchers/pull/44
 
 0.6.0

--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -19,10 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency("json-schema", "~> 2.6.0")
-  spec.add_dependency("activesupport", '>= 3.0.0')
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec-rails", ">= 2.0"
+  spec.add_development_dependency "rspec", ">= 2.0"
 end

--- a/lib/json_matchers.rb
+++ b/lib/json_matchers.rb
@@ -2,10 +2,11 @@ require "json_matchers/version"
 require "json_matchers/configuration"
 require "json_matchers/matcher"
 require "json_matchers/errors"
-require "active_support/all"
 
 module JsonMatchers
-  mattr_accessor :schema_root
+  class << self
+    attr_accessor :schema_root
+  end
 
   self.schema_root = "#{Dir.pwd}/spec/support/api/schemas"
 

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -44,6 +44,8 @@ not to match schema "#{schema_name}":
       FAIL
     end
 
+    private
+
     def pretty_json(json_string)
       JSON.pretty_generate(JSON.parse(json_string.to_s))
     end

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -159,7 +159,12 @@ describe JsonMatchers, "#match_response_schema" do
 
   def raise_formatted_error(error_message)
     raise_error do |error|
-      expect(error.message.squish).to include(error_message)
+      sanitized_message = error.message.
+        gsub(/\A[[:space:]]+/, "").
+        gsub(/[[:space:]]+\z/, "").
+        gsub(/[[:space:]]+/, " ")
+
+      expect(sanitized_message).to include(error_message)
     end
   end
 end

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -1,3 +1,6 @@
+require "fileutils"
+require "json"
+
 module FileHelpers
   ORIGINAL_SCHEMA_ROOT = JsonMatchers.schema_root
 
@@ -7,7 +10,7 @@ module FileHelpers
       when NilClass, String
         file.write(json.to_s)
       else
-        file.write(json.to_json)
+        file.write(JSON.generate(json))
       end
     end
   end


### PR DESCRIPTION
https://github.com/thoughtbot/json_matchers/pull/39

This PR replaces `rspec-rails` with `rspec`, and removes the `activesupport` dependency, which should make it easier to use this gem outside of a Rails environment. As a nice bonus, it also reduces the total number of gem dependencies (as reported by `bundle install`) from 35 to 15.

There were only 2 methods provided by ActiveSupport that were being used: `Module#mattr_accessor` and `String#strip_heredoc`. For `mattr_accessor`, I've added a (roughly) equivalent implementation, minus the instance-level getter and setter methods (which we presumably don't want anyway). As for `strip_heredoc`, I've just copied the implementation from ActiveSupport into a private method inside `JsonMatchers::RSpec`. Personally I'd de-indent the heredocs and live with the ugliness, but to each their own.

Anyway, thank you for writing this gem. I've used it in a bunch of projects when I needed to test my JSON APIs, and it's been hugely helpful :)