### PR TITLE
Fix error messages for string responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ describe "GET /posts" do
     get posts_path, format: :json
 
     expect(response.status).to eq 200
-    expect(response.body).to match_json_schema("posts")
+    expect(response.body).to match_response_schema("posts")
   end
 end
 ```

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -18,7 +18,7 @@ module JsonMatchers
 
 expected
 
-#{pretty_json(response.body)}
+#{pretty_json(response)}
 
 to match schema "#{schema_name}":
 
@@ -35,7 +35,7 @@ to match schema "#{schema_name}":
 
 expected
 
-#{pretty_json(response.body)}
+#{pretty_json(response)}
 
 not to match schema "#{schema_name}":
 
@@ -46,7 +46,8 @@ not to match schema "#{schema_name}":
 
     private
 
-    def pretty_json(json_string)
+    def pretty_json(response)
+      json_string = response.respond_to?(:body) ? response.body : response
       JSON.pretty_generate(JSON.parse(json_string.to_s))
     end
 

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -22,20 +22,30 @@ describe JsonMatchers, "#match_response_schema" do
     expect(response_for({})).not_to match_response_schema("foo_schema")
   end
 
-  it "validates a JSON string" do
-    create_schema("foo_schema", {
-      "type" => "object",
-      "required" => [
-        "id",
-      ],
-      "properties" => {
-        "id" => { "type" => "number" },
-      },
-      "additionalProperties" => false,
-    })
+  context "when JSON is a string" do
+    before(:each) do
+      create_schema("foo_schema", {
+        "type" => "object",
+        "required" => [
+          "id",
+        ],
+        "properties" => {
+          "id" => { "type" => "number" },
+        },
+        "additionalProperties" => false,
+      })
+    end
 
-    expect(response_for({ "id" => 1 }).body).
-      to match_response_schema("foo_schema")
+    it "validates when the schema matches" do
+      expect({ "id" => 1 }.to_json).
+        to match_response_schema("foo_schema")
+    end
+
+    it "fails with message when negated" do
+      expect {
+        expect({ "id" => "1" }.to_json).to match_response_schema("foo_schema")
+      }.to raise_formatted_error(%{{ "type": "number" }})
+    end
   end
 
   it "fails when the body contains a property with the wrong type" do


### PR DESCRIPTION
While `match_response_schema ` can now accept a string (thanks to https://github.com/thoughtbot/json_matchers/pull/43), I noticed it will cause a `NoMethodError` in error messages:

```
NoMethodError:
  undefined method `body' for "{\"foo\":\"bar\"}":String
```

This fix checks if response `respond_to?(:body)` before attempting to call it from the error message. Included a test for failed string responses to ensure desired behavior.

Also fixed what I think is a related typo in README: `match_json_schema` should be `match_response_schema`, correct?