### PR TITLE
Upgrade json-schema dependency to 2.7

### DIFF
--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("json-schema", "~> 2.6.0")
+  spec.add_dependency("json-schema", "~> 2.7")
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Since `addressable` is a widely used dependency today and `json-schema 2.6` has it locked to `2.3` it becomes more difficult to resolve dependency conflicts with Bundler.

Upgrading `json-schema` to `2.7` will result in `addressable >= 2.4` dependency thus should ease up such dependency conflict resolutions.