### PR TITLE
Configure matcher to `record_errors`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 master
 ======
 
+* Default `record_errors: true` [#52]
+* Add support for configuring `record_errors` [#51]
+
+[#52]: https://github.com/thoughtbot/json_matchers/pull/52
+[#51]: https://github.com/thoughtbot/json_matchers/pull/51
+
 0.6.3
 =====
 

--- a/lib/json_matchers/configuration.rb
+++ b/lib/json_matchers/configuration.rb
@@ -11,7 +11,9 @@ module JsonMatchers
     attr_reader :options
 
     def initialize
-      @options = {}
+      @options = {
+        record_errors: true,
+      }
     end
   end
 end

--- a/lib/json_matchers/validator.rb
+++ b/lib/json_matchers/validator.rb
@@ -1,0 +1,38 @@
+require "json-schema"
+require "json_matchers/payload"
+
+module JsonMatchers
+  class Validator
+    def initialize(options:, response:, schema_path:)
+      @options = options.dup
+      @payload = Payload.new(response).to_s
+      @schema_path = schema_path.to_s
+    end
+
+    def validate!
+      if recording_errors?
+        validate_recording_errors
+      else
+        validate
+      end
+    end
+
+    private
+
+    attr_reader :options, :payload, :schema_path
+
+    def recording_errors?
+      options.fetch(:record_errors, false)
+    end
+
+    def validate_recording_errors
+      JSON::Validator.fully_validate(schema_path, payload, options)
+    end
+
+    def validate
+      JSON::Validator.validate!(schema_path, payload, options)
+
+      []
+    end
+  end
+end

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -159,13 +159,24 @@ describe JsonMatchers, "#match_response_schema" do
     end
 
     context "when configured to record errors" do
-      it "fails when the body is missing a required property" do
+      it "includes the reasons for failure in the exception's message" do
         with_options(record_errors: true) do
-          create_schema("foo_schema",
-                        "type" => "object",
-                        "required" => ["foo"])
+          create_schema("foo_schema", {
+            "type" => "object",
+            "properties" => {
+              "username" => {
+                "allOf": [
+                  { "type": "string" },
+                  { "minLength": 5 }
+                ]
+              }
+            }
+          })
+          invalid_payload = response_for({ "username" => "foo" })
 
-          expect(response_for({})).not_to match_response_schema("foo_schema")
+          expect {
+            expect(invalid_payload).to match_response_schema("foo_schema")
+          }.to raise_error(/minimum/)
         end
       end
     end


### PR DESCRIPTION
Closes [#51].

By default, `JsonMatchers.configuration.options[:record_errors] = true`.

Extract `JsonMatchers::Validator` to encapsulate error reporting
behavior.

`JSON::Validator` exposes a `#validate!` method that will raise on
validation failures, and a `#fully_validate!` method that won't raise,
but will return an array of error messages instead.

Additionally, this commit introduces the `#with_options` test helper
that scopes configuration options to a given test block.

[#51]: https://github.com/thoughtbot/json_matchers/pull/51