### PR TITLE
Force `record_errors: true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ A list of available options can be found [here][options].
 
 [options]: https://github.com/ruby-json-schema/json-schema/blob/2.2.4/lib/json-schema/validator.rb#L160-L162
 
-### Default matcher options
+### Global matcher options
 
 To configure the default options passed to *all* matchers, call
 `JsonMatchers.configure`:
@@ -122,7 +122,10 @@ end
 
 A list of available options can be found [here][options].
 
-[options]: https://github.com/ruby-json-schema/json-schema/blob/2.2.4/lib/json-schema/validator.rb#L160-L162
+### Default matcher options
+
+* `record_errors: true` - *NOTE* `json_matchers` will always set
+  `record_errors: true`. This cannot be overridden.
 
 ### Embedding other Schemas
 

--- a/lib/json_matchers/configuration.rb
+++ b/lib/json_matchers/configuration.rb
@@ -8,12 +8,12 @@ module JsonMatchers
   end
 
   class Configuration
-    attr_reader :options
-
     def initialize
-      @options = {
-        record_errors: true,
-      }
+      @options = {}
+    end
+
+    def options
+      @options.merge!(record_errors: true)
     end
   end
 end

--- a/spec/json_matchers/configuration_spec.rb
+++ b/spec/json_matchers/configuration_spec.rb
@@ -1,0 +1,9 @@
+describe JsonMatchers, ".configure" do
+  it "ignores :record_errors configuration" do
+    with_options(record_errors: false) do
+      configured_options = JsonMatchers.configuration.options
+
+      expect(configured_options).to include(record_errors: true)
+    end
+  end
+end


### PR DESCRIPTION
Ensure that validation is always configured with  `record_errors: true`,
based on the following [comments]:

> By default, the underlying Validator will raise an error when passed
> invalid JSON. Unfortunately, this error tends to be high-level and
> [vague](https://github.com/thoughtbot/json_matchers/pull/51).

> When configured with `record_errors: true`, the validator will collect
> and return an array of error messages instead of raising.

> This feels like a [reasonable
> default](https://github.com/thoughtbot/json_matchers/pull/51#issuecomment-282358981),
> so this PR makes it so.

[comments]: https://github.com/thoughtbot/json_matchers/pull/52#issuecomment-282361924