### PR TITLE
Fix RSpec matcher for matching against already parsed JSON

### DIFF
--- a/lib/json_matchers/payload.rb
+++ b/lib/json_matchers/payload.rb
@@ -15,6 +15,8 @@ module JsonMatchers
     def extract_json_string(payload)
       if payload.respond_to?(:body)
         payload.body
+      elsif payload.is_a?(Hash)
+        payload.to_json
       else
         payload
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "delegate"
 require "json_matchers/rspec"
 
 Dir["./spec/support/*"].each { |file| require file }


### PR DESCRIPTION
@seanpdoyle I was hitting the same error mentioned in #56.

## Cause

 What was causing this is the following:

```ruby
RSpec.describe 'Home Request Spec', type: :request do
    describe "GET /homes/:id" do
        it 'returns a single agent' do
          get "/homes/1"
          expect(response.status).to eql(200)

          payload = JSON.parse(response.body)
          expect(payload).to match_response_schema('home')
          expect(payload['id']).to eql(1)
          # .... more assertions
        end
      end
  end
end
```

Note in the above example `expect(payload).to match_response_schema('home')` where the `payload` is an already parsed JSON string (a Ruby `Hash`) and not a Ruby `String`.

When there is a schema mismatch, the RSpec matcher calls the `pretty_json` method on all objects involved. This in turn calls [Payload.new(response)](https://github.com/jsmestad/json_matchers/blob/rspec-failure-message-for-parsed-json/lib/json_matchers/rspec.rb#L51) and fails when trying to turn the Ruby Hash into a JSON object.

## Fixes

Obviously this was caused by a user error of passing in a already-parsed JSON payload into the matcher.

A couple solutions are:

1. Fail the matcher if the expectation is set against a Hash and tell them it must be a string.
2. Convert the Hash back to JSON calling `#to_json` on it.
3. If something is already a Hash, skip any attempt at conversion.


I would argue against option 1, as many request spec helpers do automatic JSON.parse calls when the content-type is `application/json`.

So I implemented option 2, but I think the 3rd option is just as good. I was implementing tests and then saw #57 pending and figured it was better to hold off.


