### PR TITLE
Add Test coverage for Hash arguments

### DIFF
--- a/lib/json_matchers/payload.rb
+++ b/lib/json_matchers/payload.rb
@@ -15,6 +15,8 @@ module JsonMatchers
     def extract_json_string(payload)
       if payload.respond_to?(:body)
         payload.body
+      elsif payload.respond_to?(:to_h)
+        payload.to_h.to_json
       else
         payload
       end

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -1,3 +1,4 @@
+require "delegate"
 require "json_matchers"
 require "json_matchers/payload"
 

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -23,7 +23,7 @@ describe JsonMatchers, "#match_response_schema" do
   end
 
   context "when passed a Hash" do
-    before(:each) do
+    it "validates when the schema matches" do
       create_schema("foo_schema", {
         "type" => "object",
         "required" => [
@@ -34,10 +34,25 @@ describe JsonMatchers, "#match_response_schema" do
         },
         "additionalProperties" => false,
       })
+
+      expect({ "id" => 1 }).to match_response_schema("foo_schema")
     end
 
-    it "validates when the schema matches" do
-      expect({ "id" => 1 }).to match_response_schema("foo_schema")
+    it "fails with message when negated" do
+      create_schema("foo_schema", {
+        "type" => "object",
+        "required" => [
+          "id",
+        ],
+        "properties" => {
+          "id" => { "type" => "number" },
+        },
+        "additionalProperties" => false,
+      })
+
+      expect {
+        expect({ "id" => "1" }).to match_response_schema("foo_schema")
+      }.to raise_formatted_error(%{{ "type": "number" }})
     end
   end
 

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -22,6 +22,25 @@ describe JsonMatchers, "#match_response_schema" do
     expect(response_for({})).not_to match_response_schema("foo_schema")
   end
 
+  context "when passed a Hash" do
+    before(:each) do
+      create_schema("foo_schema", {
+        "type" => "object",
+        "required" => [
+          "id",
+        ],
+        "properties" => {
+          "id" => { "type" => "number" },
+        },
+        "additionalProperties" => false,
+      })
+    end
+
+    it "validates when the schema matches" do
+      expect({ "id" => 1 }).to match_response_schema("foo_schema")
+    end
+  end
+
   context "when JSON is a string" do
     before(:each) do
       create_schema("foo_schema", {


### PR DESCRIPTION
Closes [#58].

The `match_response_schema` can be chained off `expect({ ... })` calls,
so add test coverage to ensure that.

[#58]: https://github.com/thoughtbot/json_matchers/pull/58