### PR TITLE
Array as argument to `match_response_schema`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 master
 ======
 
+* Accept Array instances as arguments to `match_response_schema` [#60]
+
+[#60]: https://github.com/thoughtbot/json_matchers/issues/60
+
 0.7.1
 =====
 

--- a/lib/json_matchers/payload.rb
+++ b/lib/json_matchers/payload.rb
@@ -15,8 +15,8 @@ module JsonMatchers
     def extract_json_string(payload)
       if payload.respond_to?(:body)
         payload.body
-      elsif payload.respond_to?(:to_h)
-        payload.to_h.to_json
+      elsif payload.is_a?(Array) || payload.is_a?(Hash)
+        payload.to_json
       else
         payload
       end

--- a/spec/json_matchers/match_response_schema_spec.rb
+++ b/spec/json_matchers/match_response_schema_spec.rb
@@ -56,6 +56,45 @@ describe JsonMatchers, "#match_response_schema" do
     end
   end
 
+  context "when passed a Array" do
+    it "validates when the schema matches" do
+      create_schema("foo_schema", {
+        "type" => "array",
+        "items" => {
+          "required" => [
+            "id",
+          ],
+          "properties" => {
+            "id" => { "type" => "number" },
+          },
+          "additionalProperties" => false,
+        }
+      })
+
+      expect([{ "id" => 1 }]).to match_response_schema("foo_schema")
+    end
+
+    it "fails with message when negated" do
+      create_schema("foo_schema", {
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "required" => [
+            "id",
+          ],
+          "properties" => {
+            "id" => { "type" => "number" },
+          },
+          "additionalProperties" => false,
+        }
+      })
+
+      expect {
+        expect([{ "id" => "1" }]).to match_response_schema("foo_schema")
+      }.to raise_formatted_error(%{{ "type": "number" }})
+    end
+  end
+
   context "when JSON is a string" do
     before(:each) do
       create_schema("foo_schema", {


### PR DESCRIPTION
Closes [#60]

Add support for an Array matcher argument similar to [Hash matcher
arguments][#59].

[#59]: https://github.com/thoughtbot/json_matchers/issues/59
[#60]: https://github.com/thoughtbot/json_matchers/issues/60