### PR TITLE
Add support for Minitest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,19 +4,25 @@ inherit_from:
 Style/BlockDelimiters:
   Enabled: true
   Exclude:
+    - 'test/**/*_test.rb'
     - 'spec/**/*_spec.rb'
 
 Style/BracesAroundHashParameters:
   Enabled: true
   Exclude:
+    - 'test/**/*_test.rb'
     - 'spec/**/*_spec.rb'
     - 'spec/factories.rb'
 
 Style/SymbolArray:
   Enabled: false
 
+Layout/IndentHeredoc:
+  Enabled: false
+
 Layout/IndentHash:
   Enabled: true
   Exclude:
+    - 'test/**/*_test.rb'
     - 'spec/**/*_spec.rb'
     - 'spec/factories.rb'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Contributing to json_matchers:
+Contributing to `json_matchers`:
 
 1. Fork the [official repository](https://github.com/thoughtbot/json_matchers/tree/master).
 2. Make your changes in a topic branch.
@@ -6,5 +6,6 @@ Contributing to json_matchers:
 
 Notes:
 
-* Contributions without tests won't be accepted.
+* Contributions without tests covering the `RSpec` matchers _and_ the `Minitest`
+  assertions won't be accepted.
 * Please don't update the Gem version.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 master
 ======
 
+* Add `assert_json_matches_schema` and `refute_json_matches_schema` for
+  use in `minitest` test suites [#66]
+
+[#66]: https://github.com/thoughtbot/json_matchers/pull/66
+
 0.7.3
 =====
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Validate the JSON returned by your Rails JSON APIs
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's `Gemfile`:
 
 ```ruby
 group :test do
@@ -22,21 +22,45 @@ Or install it yourself as:
 
 ## Usage
 
-Inspired by [Validating JSON Schemas with an RSpec Matcher](http://robots.thoughtbot.com/validating-json-schemas-with-an-rspec-matcher)
+Inspired by [Validating JSON Schemas with an RSpec Matcher][original-blog-post].
 
-First, include it in your `spec_helper`:
+[original-blog-post]: (http://robots.thoughtbot.com/validating-json-schemas-with-an-rspec-matcher)
+
+First, configure it in your test suite's helper file:
+
+### Configure
+
+#### RSpec
+
+`spec/spec_helper.rb`
 
 ```ruby
-# spec/spec_helper.rb
-
 require "json_matchers/rspec"
+
+JsonMatchers.schema_root = "/spec/support/api/schemas"
 ```
 
-Define your [JSON Schema](http://json-schema.org/example1.html) in the schema directory:
+#### Minitest
+
+`test/test_helper.rb`
+
+```ruby
+require "minitest/autorun"
+require "json_matchers/minitest/assertions"
+
+JsonMatchers.schema_root = "/test/support/api/schemas"
+
+Minitest::Test.send(:include, JsonMatchers::Minitest::Assertions)
+```
+
+### Declare
+
+Declare your [JSON Schema](http://json-schema.org/example1.html) in the schema
+directory.
+
+`spec/support/api/schemas/posts.json` or `test/support/api/schemas/posts.json`:
 
 ```json
-# spec/support/api/schemas/posts.json
-
 {
   "type": "object",
   "required": ["posts"],
@@ -56,11 +80,16 @@ Define your [JSON Schema](http://json-schema.org/example1.html) in the schema di
 }
 ```
 
-Then, validate `response` against your schema with `match_json_schema`
+### Validate
+
+#### RSpec
+
+Validate a JSON response, a Hash, or a String against a JSON Schema with
+`match_json_schema`:
+
+`spec/requests/posts_spec.rb`
 
 ```ruby
-# spec/requests/posts_spec.rb
-
 describe "GET /posts" do
   it "returns Posts" do
     get posts_path, format: :json
@@ -71,18 +100,19 @@ describe "GET /posts" do
 end
 ```
 
-Alternatively, `match_json_schema` accepts a string:
+#### Minitest
+
+Validate a JSON response, a Hash, or a String against a JSON Schema with
+`assert_matches_json_schema`:
+
+`test/integration/posts_test.rb`
 
 ```ruby
-# spec/requests/posts_spec.rb
+def test_GET_posts_returns_Posts
+  get posts_path, format: :json
 
-describe "GET /posts" do
-  it "returns Posts" do
-    get posts_path, format: :json
-
-    expect(response.status).to eq 200
-    expect(response.body).to match_json_schema("posts")
-  end
+  assert_equal response.status, 200
+  assert_matches_json_schema response, "posts"
 end
 ```
 
@@ -90,9 +120,9 @@ end
 
 The matcher accepts options, which it passes to the validator:
 
-```ruby
-# spec/requests/posts_spec.rb
+`spec/requests/posts_spec.rb`
 
+```ruby
 describe "GET /posts" do
   it "returns Posts" do
     get posts_path, format: :json
@@ -110,11 +140,11 @@ A list of available options can be found [here][options].
 ### Global matcher options
 
 To configure the default options passed to *all* matchers, call
-`JsonMatchers.configure`:
+`JsonMatchers.configure`.
+
+`spec/support/json_matchers.rb`:
 
 ```rb
-# spec/support/json_matchers.rb
-
 JsonMatchers.configure do |config|
   config.options[:strict] = true
 end
@@ -133,9 +163,9 @@ To DRY up your schema definitions, use JSON schema's `$ref`.
 
 First, declare the singular version of your schema.
 
-```json
-# spec/support/api/schemas/post.json
+`spec/support/api/schemas/post.json`:
 
+```json
 {
   "type": "object",
   "required": ["id", "title", "body"],
@@ -149,9 +179,9 @@ First, declare the singular version of your schema.
 
 Then, when you declare your collection schema, reference your singular schemas.
 
-```json
-# spec/support/api/schemas/posts.json
+`spec/support/api/schemas/posts.json`:
 
+```json
 {
   "type": "object",
   "required": ["posts"],
@@ -171,19 +201,6 @@ In this case `"post.json"` will be resolved relative to
 
 To learn more about `$ref`, check out [Understanding JSON Schema Structuring](http://spacetelescope.github.io/understanding-json-schema/structuring.html)
 
-## Configuration
-
-By default, the schema directory is `spec/support/api/schemas`.
-
-This can be configured via `JsonMatchers.schema_root`.
-
-
-```ruby
-# spec/support/json_matchers.rb
-
-JsonMatchers.schema_root = "docs/api/schemas"
-```
-
 ## Contributing
 
 Please see [CONTRIBUTING].
@@ -191,7 +208,7 @@ Please see [CONTRIBUTING].
 `json_matchers` was inspired by [Validating JSON Schemas with an
 RSpec Matcher][blog post] by Laila Winner.
 
-`json_matchers` was written and is maintained by Sean Doyle.
+`json_matchers` is maintained by Sean Doyle.
 
 Many improvements and bugfixes were contributed by the [open source community].
 
@@ -201,7 +218,7 @@ Many improvements and bugfixes were contributed by the [open source community].
 
 ## License
 
-json_matchers is Copyright © 2015 Sean Doyle and thoughtbot.
+`json_matchers` is Copyright © 2018 thoughtbot.
 
 It is free software, and may be redistributed under the terms specified in the
 [LICENSE] file.

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,14 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "rake/testtask"
 
 RSpec::Core::RakeTask.new do |t|
   t.pattern = "spec/**/*_spec.rb"
 end
 
+Rake::TestTask.new do |t|
+  t.test_files = FileList["test/**/*_test.rb"]
+end
+
 task(:default).clear
-task default: [:spec]
+task default: [:spec, :test]

--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", ">= 2.0"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "factory_bot", ">= 4.8"
   spec.add_development_dependency "activesupport"
 end

--- a/lib/json_matchers.rb
+++ b/lib/json_matchers.rb
@@ -8,8 +8,6 @@ module JsonMatchers
     attr_accessor :schema_root
   end
 
-  self.schema_root = "#{Dir.pwd}/spec/support/api/schemas"
-
   def self.path_to_schema(schema_name)
     Pathname(schema_root).join("#{schema_name}.json")
   end

--- a/lib/json_matchers/assertion.rb
+++ b/lib/json_matchers/assertion.rb
@@ -1,0 +1,68 @@
+require "json"
+require "json_matchers"
+require "json_matchers/payload"
+require "json_matchers/matcher"
+
+module JsonMatchers
+  class Assertion
+    def initialize(schema_name, **options)
+      @schema_name = schema_name
+      @schema_path = JsonMatchers.path_to_schema(schema_name)
+      @matcher = Matcher.new(schema_path, options)
+    end
+
+    def valid?(json)
+      @payload = Payload.new(json)
+
+      matcher.matches?(payload.to_s)
+    end
+
+    def valid_failure_message
+      <<-FAIL
+#{last_error_message}
+
+---
+
+expected
+
+#{format_json(payload)}
+
+to match schema "#{schema_name}":
+
+#{format_json(schema_body)}
+      FAIL
+    end
+
+    def invalid_failure_message
+      <<-FAIL
+#{last_error_message}
+
+---
+
+expected
+
+#{format_json(payload)}
+
+not to match schema "#{schema_name}":
+
+#{format_json(schema_body)}
+      FAIL
+    end
+
+    private
+
+    attr_reader :payload, :matcher, :schema_name, :schema_path
+
+    def last_error_message
+      matcher.validation_failure_message
+    end
+
+    def schema_body
+      File.read(schema_path)
+    end
+
+    def format_json(json)
+      JSON.pretty_generate(JSON.parse(json.to_s))
+    end
+  end
+end

--- a/lib/json_matchers/matcher.rb
+++ b/lib/json_matchers/matcher.rb
@@ -8,8 +8,8 @@ module JsonMatchers
       @options = default_options.merge(options)
     end
 
-    def matches?(response)
-      validator = build_validator(response)
+    def matches?(payload)
+      validator = build_validator(payload)
 
       self.errors = validator.validate!
 
@@ -34,10 +34,10 @@ module JsonMatchers
       JsonMatchers.configuration.options || {}
     end
 
-    def build_validator(response)
+    def build_validator(payload)
       Validator.new(
         options: options,
-        response: response,
+        payload: payload,
         schema_path: schema_path,
       )
     end

--- a/lib/json_matchers/minitest/assertions.rb
+++ b/lib/json_matchers/minitest/assertions.rb
@@ -1,0 +1,26 @@
+require "json_matchers"
+require "json_matchers/assertion"
+
+module JsonMatchers
+  self.schema_root = File.join("test", "support", "api", "schemas")
+
+  module Minitest
+    module Assertions
+      def assert_matches_json_schema(payload, schema_name)
+        assertion = Assertion.new(schema_name)
+
+        payload_is_valid = assertion.valid?(payload)
+
+        assert payload_is_valid, -> { assertion.valid_failure_message }
+      end
+
+      def refute_matches_json_schema(payload, schema_name)
+        assertion = Assertion.new(schema_name)
+
+        payload_is_valid = assertion.valid?(payload)
+
+        refute payload_is_valid, -> { assertion.invalid_failure_message }
+      end
+    end
+  end
+end

--- a/lib/json_matchers/payload.rb
+++ b/lib/json_matchers/payload.rb
@@ -18,7 +18,7 @@ module JsonMatchers
       elsif payload.is_a?(Array) || payload.is_a?(Hash)
         payload.to_json
       else
-        payload
+        payload.to_s
       end
     end
   end

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -1,94 +1,34 @@
-require "delegate"
 require "json_matchers"
-require "json_matchers/payload"
+require "json_matchers/assertion"
 
 module JsonMatchers
-  class RSpec < SimpleDelegator
-    attr_reader :schema_name
+  self.schema_root = File.join("spec", "support", "api", "schemas")
+end
 
-    def initialize(schema_name, **options)
-      @schema_name = schema_name.to_s
+RSpec::Matchers.define :match_json_schema do |schema_name, **options|
+  assertion = JsonMatchers::Assertion.new(schema_name.to_s, options)
 
-      super(JsonMatchers::Matcher.new(schema_path, options))
+  match do |json|
+    assertion.valid?(json)
+  end
+
+  if respond_to?(:failure_message)
+    failure_message do
+      assertion.valid_failure_message
     end
 
-    def failure_message(json)
-      <<-FAIL
-#{validation_failure_message}
-
----
-
-expected
-
-#{pretty_json(json)}
-
-to match schema "#{schema_name}":
-
-#{pretty_json(schema_body)}
-
-      FAIL
+    failure_message_when_negated do
+      assertion.invalid_failure_message
+    end
+  else
+    failure_message_for_should do
+      assertion.valid_failure_message
     end
 
-    def failure_message_when_negated(json)
-      <<-FAIL
-#{validation_failure_message}
-
----
-
-expected
-
-#{pretty_json(json)}
-
-not to match schema "#{schema_name}":
-
-#{pretty_json(schema_body)}
-
-      FAIL
-    end
-
-    private
-
-    def pretty_json(json)
-      payload = Payload.new(json).to_s
-
-      JSON.pretty_generate(JSON.parse(payload))
-    end
-
-    def schema_path
-      JsonMatchers.path_to_schema(schema_name)
-    end
-
-    def schema_body
-      File.read(schema_path)
+    failure_message_for_should_not do
+      assertion.invalid_failure_message
     end
   end
 end
 
-if RSpec.respond_to?(:configure)
-  RSpec::Matchers.define :match_json_schema do |schema_name, **options|
-    matcher = JsonMatchers::RSpec.new(schema_name, options)
-
-    match do |json|
-      matcher.matches?(json)
-    end
-
-    if respond_to?(:failure_message)
-      failure_message do |json|
-        matcher.failure_message(json)
-      end
-
-      failure_message_when_negated do |json|
-        matcher.failure_message_when_negated(json)
-      end
-    else
-      failure_message_for_should do |json|
-        matcher.failure_message(json)
-      end
-
-      failure_message_for_should_not do |json|
-        matcher.failure_message_when_negated(json)
-      end
-    end
-  end
-  RSpec::Matchers.alias_matcher :match_response_schema, :match_json_schema
-end
+RSpec::Matchers.alias_matcher :match_response_schema, :match_json_schema

--- a/lib/json_matchers/validator.rb
+++ b/lib/json_matchers/validator.rb
@@ -1,11 +1,10 @@
 require "json-schema"
-require "json_matchers/payload"
 
 module JsonMatchers
   class Validator
-    def initialize(options:, response:, schema_path:)
+    def initialize(options:, payload:, schema_path:)
       @options = options.dup
-      @payload = Payload.new(response).to_s
+      @payload = payload
       @schema_path = schema_path.to_s
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,20 +1,25 @@
+require "json_matchers/payload"
+require_relative "./support/fake_response"
+require_relative "./support/fake_schema"
+
 FactoryBot.define do
   factory :response, class: FakeResponse do
     skip_create
 
     trait :object do
-      body { { "id": 1 }.to_json }
+      body { { "id": 1 } }
     end
 
     trait :invalid_object do
-      body { { "id": "1" }.to_json }
+      body { { "id": "1" } }
     end
 
     initialize_with do
       body = attributes.fetch(:body, nil)
-      payload = attributes.except(:body)
+      json = attributes.except(:body)
+      payload = JsonMatchers::Payload.new(body || json)
 
-      FakeResponse.new(body || payload.to_json)
+      FakeResponse.new(payload.to_s)
     end
   end
 

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/string"
+
 describe JsonMatchers, "#match_json_schema" do
   it "fails with an invalid JSON schema" do
     schema = create(:schema, :invalid)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require "json_matchers/rspec"
-require "active_support/core_ext/string"
 
-Dir["./spec/support/*"].each { |file| require file }
+Dir["./spec/support/**/*.rb"].each { |file| require file }
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/test/json_matchers/minitest/assertions_test.rb
+++ b/test/json_matchers/minitest/assertions_test.rb
@@ -1,0 +1,177 @@
+require_relative "../../test_helper"
+require "active_support/core_ext/string"
+
+class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
+  test "fails with an invalid JSON schema" do
+    schema = create(:schema, :invalid)
+
+    json = build(:response)
+
+    assert_raises JsonMatchers::InvalidSchemaError do
+      assert_matches_json_schema(json, schema)
+    end
+  end
+
+  test "does not fail with an empty JSON body" do
+    schema = create(:schema, {})
+
+    json = build(:response, {})
+
+    assert_matches_json_schema(json, schema)
+  end
+
+  test "fails when the body contains a property with the wrong type" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :invalid_object)
+
+    refute_matches_json_schema(json, schema)
+  end
+
+  test "fails when the body is missing a required property" do
+    schema = create(:schema, :object)
+
+    json = build(:response, {})
+
+    refute_matches_json_schema(json, schema)
+  end
+
+  test "when passed a Hash, validates that the schema matches" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :object)
+    json_as_hash = json.to_h
+
+    assert_matches_json_schema(json_as_hash, schema)
+  end
+
+  test "when passed a Hash, fails with message when negated" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :invalid_object)
+    json_as_hash = json.to_h
+
+    assert_raises_error_containing(schema) do
+      assert_matches_json_schema(json_as_hash, schema)
+    end
+  end
+
+  test "when passed a Array, validates a root-level Array in the JSON" do
+    schema = create(:schema, :array_of, :objects)
+
+    json = build(:response, :object)
+    json_as_array = [json.to_h]
+
+    assert_matches_json_schema(json_as_array, schema)
+  end
+
+  test "when passed a Array, refutes a root-level Array in the JSON" do
+    schema = create(:schema, :array_of, :objects)
+
+    json = build(:response, :invalid_object)
+    json_as_array = [json.to_h]
+
+    refute_matches_json_schema(json_as_array, schema)
+  end
+
+  test "when passed a Array, fails with message when negated" do
+    schema = create(:schema, :array_of, :object)
+
+    json = build(:response, :invalid_object)
+    json_as_array = [json.to_h]
+
+    assert_raises_error_containing(schema) do
+      assert_matches_json_schema(json_as_array, schema)
+    end
+  end
+
+  test "when JSON is a string, validates that the schema matches" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :object)
+    json_as_string = json.to_json
+
+    assert_matches_json_schema(json_as_string, schema)
+  end
+
+  test "when JSON is a string, fails with message when negated" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :invalid_object)
+    json_as_string = json.to_json
+
+    assert_raises_error_containing(schema) do
+      assert_matches_json_schema(json_as_string, schema)
+    end
+  end
+
+  test "the failure message contains the body" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :invalid_object)
+
+    assert_raises_error_containing(json) do
+      assert_matches_json_schema(json, schema)
+    end
+  end
+
+  test "the failure message contains the schema" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :invalid_object)
+
+    assert_raises_error_containing(schema) do
+      assert_matches_json_schema(json, schema)
+    end
+  end
+
+  test "the failure message when negated, contains the body" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :object)
+
+    assert_raises_error_containing(json) do
+      refute_matches_json_schema(json, schema)
+    end
+  end
+
+  test "the failure message when negated, contains the schema" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :object)
+
+    assert_raises_error_containing(schema) do
+      refute_matches_json_schema(json, schema)
+    end
+  end
+
+  test "asserts valid JSON against a schema that uses $ref" do
+    schema = create(:schema, :referencing_objects)
+
+    json = build(:response, :object)
+    json_as_array = [json.to_h]
+
+    assert_matches_json_schema(json_as_array, schema)
+  end
+
+  test "refutes valid JSON against a schema that uses $ref" do
+    schema = create(:schema, :referencing_objects)
+
+    json = build(:response, :invalid_object)
+    json_as_array = [json.to_h]
+
+    refute_matches_json_schema(json_as_array, schema)
+  end
+
+  def assert_raises_error_containing(schema_or_body)
+    raised_error = assert_raises(Minitest::Assertion) do
+      yield
+    end
+
+    sanitized_message = raised_error.message.squish
+    json = JSON.pretty_generate(schema_or_body.to_h)
+    error_message = json.squish
+
+    assert_includes sanitized_message, error_message
+  end
+end

--- a/test/support/factory_bot.rb
+++ b/test/support/factory_bot.rb
@@ -1,0 +1,5 @@
+require "factory_bot"
+
+FactoryBot.find_definitions
+
+Minitest::Test.send(:include, FactoryBot::Syntax::Methods)

--- a/test/support/json_matchers/test_case.rb
+++ b/test/support/json_matchers/test_case.rb
@@ -1,0 +1,18 @@
+require "active_support/testing/declarative"
+require_relative "../../../spec/support/file_helpers"
+
+module JsonMatchers
+  class TestCase < ::Minitest::Test
+    extend ActiveSupport::Testing::Declarative
+
+    include FileHelpers
+
+    def setup
+      @original_schema_root = setup_fixtures("test", "fixtures", "schemas")
+    end
+
+    def teardown
+      teardown_fixtures(@original_schema_root)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,8 @@
+require "minitest/autorun"
+require "json_matchers/minitest/assertions"
+
+JsonMatchers.schema_root = "/test/support/api/schemas"
+
+Minitest::Test.send(:include, JsonMatchers::Minitest::Assertions)
+
+Dir["./test/support/**/*.rb"].each { |file| require file }


### PR DESCRIPTION
Introduce `JsonMatchers::Minitest::Assertions` module, which provides
`assert_response_matches_schema` and `refute_response_matches_schema`
assertion methods.

Configure Hound to allow JSON-like hash declarations inside
`test/**/*_test.rb` files like `spec/**/*_spec.rb` files.

Add `rake test` to compliment `rake spec`. Rake's `default` task, which
is run in CI, will run both `rake test` and `rake spec`.

When including the Minitest assertions, the schema directory will
default to `test/support/api/schemas`.

This commit re-implements the RSpec matcher to re-use
`JsonMatchers::Assertion` instead of declaring `JsonMatchers::Rspec`.

Update the `README.md` to explain how to configure and use the Minitest
assertions.

Update `CONTRIBUTING.md` to explain that pull requests _must_ include
tests that cover both `Minitest` and `RSpec`.