### PR TITLE
Simplify internal test setup

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,4 +10,12 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+
+  config.include FileHelpers
+
+  config.around do |example|
+    ensure_fixtures("spec", "fixtures", "schemas") do
+      example.run
+    end
+  end
 end


### PR DESCRIPTION
Add `setup_fixtures`, `teardown_fixtures`, and `ensure_fixtures` test
helpers to manage the test suite's schema files.

Move the `RSpec.configure` block out of the `FileHelpers` module, and
into the `spec/spec_helper`'s corresponding block.

By doing so, the `FileHelpers` module can be `require`'d and `include`'d
without additional test framework-specific side-effects.