### PR TITLE
Alias matcher to `match_json_schema`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 master
 ======
 
+* Alias `match_response_schema` to `match_json_schema`. These matches can
+  validate any JSON, whether it's from a request body, a response body, a Hash,
+  or a String. [#68]
+
+[#68]: https://github.com/thoughtbot/json_matchers/pull/68
+
 0.7.2
 =====
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Define your [JSON Schema](http://json-schema.org/example1.html) in the schema di
 }
 ```
 
-Then, validate `response` against your schema with `match_response_schema`
+Then, validate `response` against your schema with `match_json_schema`
 
 ```ruby
 # spec/requests/posts_spec.rb
@@ -66,12 +66,12 @@ describe "GET /posts" do
     get posts_path, format: :json
 
     expect(response.status).to eq 200
-    expect(response).to match_response_schema("posts")
+    expect(response).to match_json_schema("posts")
   end
 end
 ```
 
-Alternatively, `match_response_schema` accepts a string:
+Alternatively, `match_json_schema` accepts a string:
 
 ```ruby
 # spec/requests/posts_spec.rb
@@ -81,7 +81,7 @@ describe "GET /posts" do
     get posts_path, format: :json
 
     expect(response.status).to eq 200
-    expect(response.body).to match_response_schema("posts")
+    expect(response.body).to match_json_schema("posts")
   end
 end
 ```
@@ -98,7 +98,7 @@ describe "GET /posts" do
     get posts_path, format: :json
 
     expect(response.status).to eq 200
-    expect(response).to match_response_schema("posts", strict: true)
+    expect(response).to match_json_schema("posts", strict: true)
   end
 end
 ```

--- a/lib/json_matchers/rspec.rb
+++ b/lib/json_matchers/rspec.rb
@@ -12,7 +12,7 @@ module JsonMatchers
       super(JsonMatchers::Matcher.new(schema_path, options))
     end
 
-    def failure_message(response)
+    def failure_message(json)
       <<-FAIL
 #{validation_failure_message}
 
@@ -20,7 +20,7 @@ module JsonMatchers
 
 expected
 
-#{pretty_json(response)}
+#{pretty_json(json)}
 
 to match schema "#{schema_name}":
 
@@ -29,7 +29,7 @@ to match schema "#{schema_name}":
       FAIL
     end
 
-    def failure_message_when_negated(response)
+    def failure_message_when_negated(json)
       <<-FAIL
 #{validation_failure_message}
 
@@ -37,7 +37,7 @@ to match schema "#{schema_name}":
 
 expected
 
-#{pretty_json(response)}
+#{pretty_json(json)}
 
 not to match schema "#{schema_name}":
 
@@ -48,8 +48,8 @@ not to match schema "#{schema_name}":
 
     private
 
-    def pretty_json(response)
-      payload = Payload.new(response).to_s
+    def pretty_json(json)
+      payload = Payload.new(json).to_s
 
       JSON.pretty_generate(JSON.parse(payload))
     end
@@ -65,29 +65,30 @@ not to match schema "#{schema_name}":
 end
 
 if RSpec.respond_to?(:configure)
-  RSpec::Matchers.define :match_response_schema do |schema_name, **options|
+  RSpec::Matchers.define :match_json_schema do |schema_name, **options|
     matcher = JsonMatchers::RSpec.new(schema_name, options)
 
-    match do |response|
-      matcher.matches?(response)
+    match do |json|
+      matcher.matches?(json)
     end
 
     if respond_to?(:failure_message)
-      failure_message do |response|
-        matcher.failure_message(response)
+      failure_message do |json|
+        matcher.failure_message(json)
       end
 
-      failure_message_when_negated do |response|
-        matcher.failure_message_when_negated(response)
+      failure_message_when_negated do |json|
+        matcher.failure_message_when_negated(json)
       end
     else
-      failure_message_for_should do |response|
-        matcher.failure_message(response)
+      failure_message_for_should do |json|
+        matcher.failure_message(json)
       end
 
-      failure_message_for_should_not do |response|
-        matcher.failure_message_when_negated(response)
+      failure_message_for_should_not do |json|
+        matcher.failure_message_when_negated(json)
       end
     end
   end
+  RSpec::Matchers.alias_matcher :match_response_schema, :match_json_schema
 end

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -1,16 +1,16 @@
-describe JsonMatchers, "#match_response_schema" do
+describe JsonMatchers, "#match_json_schema" do
   it "fails with an invalid JSON body" do
     create_schema("foo", "")
 
     expect {
-      expect(response_for("")).to match_response_schema("foo")
+      expect(response_for("")).to match_json_schema("foo")
     }.to raise_error(JsonMatchers::InvalidSchemaError)
   end
 
   it "does not fail with an empty JSON body" do
     create_schema("foo", {})
 
-    expect(response_for({})).to match_response_schema("foo")
+    expect(response_for({})).to match_json_schema("foo")
   end
 
   it "fails when the body is missing a required property" do
@@ -19,7 +19,7 @@ describe JsonMatchers, "#match_response_schema" do
       "required": ["foo"],
     })
 
-    expect(response_for({})).not_to match_response_schema("foo_schema")
+    expect(response_for({})).not_to match_json_schema("foo_schema")
   end
 
   context "when passed a Hash" do
@@ -35,7 +35,7 @@ describe JsonMatchers, "#match_response_schema" do
         "additionalProperties": false,
       })
 
-      expect({ "id": 1 }).to match_response_schema("foo_schema")
+      expect({ "id": 1 }).to match_json_schema("foo_schema")
     end
 
     it "fails with message when negated" do
@@ -51,7 +51,7 @@ describe JsonMatchers, "#match_response_schema" do
       })
 
       expect {
-        expect({ "id": "1" }).to match_response_schema("foo_schema")
+        expect({ "id": "1" }).to match_json_schema("foo_schema")
       }.to raise_formatted_error(%{{ "type": "number" }})
     end
   end
@@ -71,7 +71,7 @@ describe JsonMatchers, "#match_response_schema" do
         },
       })
 
-      expect([{ "id": 1 }]).to match_response_schema("foo_schema")
+      expect([{ "id": 1 }]).to match_json_schema("foo_schema")
     end
 
     it "fails with message when negated" do
@@ -90,7 +90,7 @@ describe JsonMatchers, "#match_response_schema" do
       })
 
       expect {
-        expect([{ "id": "1" }]).to match_response_schema("foo_schema")
+        expect([{ "id": "1" }]).to match_json_schema("foo_schema")
       }.to raise_formatted_error(%{{ "type": "number" }})
     end
   end
@@ -111,12 +111,12 @@ describe JsonMatchers, "#match_response_schema" do
 
     it "validates when the schema matches" do
       expect({ "id": 1 }.to_json).
-        to match_response_schema("foo_schema")
+        to match_json_schema("foo_schema")
     end
 
     it "fails with message when negated" do
       expect {
-        expect({ "id": "1" }.to_json).to match_response_schema("foo_schema")
+        expect({ "id": "1" }.to_json).to match_json_schema("foo_schema")
       }.to raise_formatted_error(%{{ "type": "number" }})
     end
   end
@@ -130,14 +130,14 @@ describe JsonMatchers, "#match_response_schema" do
     })
 
     expect(response_for("foo": 1)).
-      not_to match_response_schema("foo_schema")
+      not_to match_json_schema("foo_schema")
   end
 
   it "contains the body in the failure message" do
     create_schema("foo", { "type": "array" })
 
     expect {
-      expect(response_for("bar": 5)).to match_response_schema("foo")
+      expect(response_for("bar": 5)).to match_json_schema("foo")
     }.to raise_formatted_error(%{{ "bar": 5 }})
   end
 
@@ -145,7 +145,7 @@ describe JsonMatchers, "#match_response_schema" do
     create_schema("foo", { "type": "array" })
 
     expect {
-      expect(response_for([])).not_to match_response_schema("foo")
+      expect(response_for([])).not_to match_json_schema("foo")
     }.to raise_formatted_error("[ ]")
   end
 
@@ -154,7 +154,7 @@ describe JsonMatchers, "#match_response_schema" do
     create_schema("foo", schema)
 
     expect {
-      expect(response_for("bar": 5)).to match_response_schema("foo")
+      expect(response_for("bar": 5)).to match_json_schema("foo")
     }.to raise_formatted_error(%{{ "type": "array" }})
   end
 
@@ -163,7 +163,7 @@ describe JsonMatchers, "#match_response_schema" do
     create_schema("foo", schema)
 
     expect {
-      expect(response_for([])).not_to match_response_schema("foo")
+      expect(response_for([])).not_to match_json_schema("foo")
     }.to raise_formatted_error(%{{ "type": "array" }})
   end
 
@@ -173,7 +173,7 @@ describe JsonMatchers, "#match_response_schema" do
       "items": { "type": "string" },
     })
 
-    expect(response_for(["valid"])).to match_response_schema("array_schema")
+    expect(response_for(["valid"])).to match_json_schema("array_schema")
   end
 
   it "supports $ref" do
@@ -192,7 +192,9 @@ describe JsonMatchers, "#match_response_schema" do
     valid_response = response_for([{ "foo": "is a string" }])
     invalid_response = response_for([{ "foo": 0 }])
 
+    expect(valid_response).to match_json_schema("collection")
     expect(valid_response).to match_response_schema("collection")
+    expect(invalid_response).not_to match_json_schema("collection")
     expect(invalid_response).not_to match_response_schema("collection")
   end
 
@@ -207,9 +209,9 @@ describe JsonMatchers, "#match_response_schema" do
       })
 
       expect(response_for({ "id": 1, "title": "bar" })).
-        to match_response_schema("foo_schema", strict: true)
+        to match_json_schema("foo_schema", strict: true)
       expect(response_for({ "id": 1 })).
-        not_to match_response_schema("foo_schema", strict: true)
+        not_to match_json_schema("foo_schema", strict: true)
     end
   end
 
@@ -225,9 +227,9 @@ describe JsonMatchers, "#match_response_schema" do
         })
 
         expect(response_for({ "id": 1, "title": "bar" })).
-          to match_response_schema("foo_schema")
+          to match_json_schema("foo_schema")
         expect(response_for({ "id": 1 })).
-          not_to match_response_schema("foo_schema")
+          not_to match_json_schema("foo_schema")
       end
     end
 
@@ -248,7 +250,7 @@ describe JsonMatchers, "#match_response_schema" do
           invalid_payload = response_for({ "username": "foo" })
 
           expect {
-            expect(invalid_payload).to match_response_schema("foo_schema")
+            expect(invalid_payload).to match_json_schema("foo_schema")
           }.to raise_error(/minimum/)
         end
       end


### PR DESCRIPTION
These matches can validate any JSON, whether it's from a request body,
a response body, a Hash, or a String.

This commit declares the matcher as `match_json_schema`, and defines an
RSpec matcher alias with [`RSpec::Matchers#alias_matcher`][code].

For the sake of backward compatibility, both matchers will be supported
until `match_response_schema` is deprecated.

[code]: https://github.com/rspec/rspec-expectations/blob/c8c181821f4d3f53f8a4370086e02cbdb2f80b89/lib/rspec/matchers.rb#L65-L83