### PR TITLE
Add `factory_bot` for building test data

### DIFF
--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", ">= 2.0"
+  spec.add_development_dependency "factory_bot", ">= 4.8"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  FakeResponse = Struct.new(:body)
+
+  factory :response, class: FakeResponse do
+    skip_create
+
+    initialize_with do
+      body = attributes[:body]
+      payload = attributes.except(:body)
+
+      FakeResponse.new(body || payload.to_json)
+    end
+  end
+end

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -41,7 +41,9 @@ describe JsonMatchers, "#match_json_schema" do
         "additionalProperties": false,
       })
 
-      expect({ "id": 1 }).to match_json_schema("foo_schema")
+      json = { "id": 1 }
+
+      expect(json).to match_json_schema("foo_schema")
     end
 
     it "fails with message when negated" do
@@ -56,8 +58,10 @@ describe JsonMatchers, "#match_json_schema" do
         "additionalProperties": false,
       })
 
+      json = { "id": "1" }
+
       expect {
-        expect({ "id": "1" }).to match_json_schema("foo_schema")
+        expect(json).to match_json_schema("foo_schema")
       }.to raise_formatted_error(%{{ "type": "number" }})
     end
   end
@@ -77,7 +81,9 @@ describe JsonMatchers, "#match_json_schema" do
         },
       })
 
-      expect([{ "id": 1 }]).to match_json_schema("foo_schema")
+      json = [{ "id": 1 }]
+
+      expect(json).to match_json_schema("foo_schema")
     end
 
     it "fails with message when negated" do
@@ -95,14 +101,16 @@ describe JsonMatchers, "#match_json_schema" do
         },
       })
 
+      json = [{ "id": "1" }]
+
       expect {
-        expect([{ "id": "1" }]).to match_json_schema("foo_schema")
+        expect(json).to match_json_schema("foo_schema")
       }.to raise_formatted_error(%{{ "type": "number" }})
     end
   end
 
   context "when JSON is a string" do
-    before(:each) do
+    it "validates when the schema matches" do
       create_schema("foo_schema", {
         "type": "object",
         "required": [
@@ -113,16 +121,28 @@ describe JsonMatchers, "#match_json_schema" do
         },
         "additionalProperties": false,
       })
-    end
 
-    it "validates when the schema matches" do
-      expect({ "id": 1 }.to_json).
-        to match_json_schema("foo_schema")
+      json = { "id": 1 }.to_json
+
+      expect(json).to match_json_schema("foo_schema")
     end
 
     it "fails with message when negated" do
+      create_schema("foo_schema", {
+        "type": "object",
+        "required": [
+          "id",
+        ],
+        "properties": {
+          "id": { "type": "number" },
+        },
+        "additionalProperties": false,
+      })
+
+      json = { "id": "1" }.to_json
+
       expect {
-        expect({ "id": "1" }.to_json).to match_json_schema("foo_schema")
+        expect(json).to match_json_schema("foo_schema")
       }.to raise_formatted_error(%{{ "type": "number" }})
     end
   end
@@ -266,6 +286,7 @@ describe JsonMatchers, "#match_json_schema" do
               },
             },
           })
+
           invalid_json = build(:response, { "username": "foo" })
 
           expect {

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,9 @@
+require "factory_bot"
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
+end

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -2,8 +2,6 @@ require "fileutils"
 require "json"
 
 module FileHelpers
-  FakeResponse = Struct.new(:body)
-
   def create_schema(name, json)
     path = File.join(JsonMatchers.schema_root, "#{name}.json")
 
@@ -15,16 +13,6 @@ module FileHelpers
         file.write(JSON.generate(json))
       end
     end
-  end
-
-  def response_for(json)
-    response_body = case json
-                    when String, NilClass
-                      json.to_s
-                    else
-                      json.to_json
-                    end
-    FakeResponse.new(response_body)
   end
 
   def setup_fixtures(*pathnames)


### PR DESCRIPTION
Add `factory_bot` for building test data
---

Define the `response` factory to replace the `response_for` helper.

To work around `FactoryBot`'s expectations for its arguments to be a
factory name, traits, then a Hash of attributes, the factory accepts a
`body:` for building invalid JSON or JSON that has an Array as its root.

Otherwise, the factory builds a dummy object that response to `#body`
that returns the attributes as JSON.


Separate tests' `json` declaration as Exercise
---

Since the tests cover a testing tool, separating the Exercise [phase] from
the Verification phase is tricky.

This commit pulls out in-line `json` declarations into the Exercise
phase, and separates them from the Verification phase with lines of
whitespace.

[phase]: https://robots.thoughtbot.com/four-phase-test