### PR TITLE
WIP: Make Tests utilize factories

### DIFF
--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", ">= 2.0"
   spec.add_development_dependency "factory_bot", ">= 4.8"
+  spec.add_development_dependency "activesupport"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -52,9 +52,12 @@ FactoryBot.define do
 
     trait :array do
       initialize_with do
+        schema_body_as_json = attributes.fetch(:json, nil)
+        schema_body = attributes.except(:json, :name)
+
         FakeSchema.new(name, {
           "type": "array",
-          "items": json,
+          "items": schema_body_as_json || schema_body,
         })
       end
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     def to_h
       JSON.parse(body)
     end
+
+    def to_json
+      body
+    end
   end
   FakeSchema = Struct.new(:name, :json) do
     def to_h
@@ -17,6 +21,10 @@ FactoryBot.define do
   end
 
   factory :response, class: FakeResponse do
+    trait :with_id do
+      body { { "id": 1 }.to_json }
+    end
+
     skip_create
 
     initialize_with do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     skip_create
 
     initialize_with do
-      body = attributes[:body]
+      body = attributes.fetch(:body, nil)
       payload = attributes.except(:body)
 
       FakeResponse.new(body || payload.to_json)
@@ -34,14 +34,38 @@ FactoryBot.define do
       json { "" }
     end
 
+    trait :with_id do
+      json do
+        {
+          "type": "object",
+          "required": [
+            "id",
+          ],
+          "properties": {
+            "id": { "type": "number" },
+          },
+          "additionalProperties": false,
+        }
+      end
+    end
+    trait(:with_ids) { with_id }
+
+    trait :array do
+      initialize_with do
+        FakeSchema.new(name, {
+          "type": "array",
+          "items": json,
+        })
+      end
+    end
+
     skip_create
 
     initialize_with do
-      name = attributes.fetch(:name)
-      json_attribute = attributes.fetch(:json, nil)
-      attributes_as_json = attributes.except(:json, :name)
+      schema_body_as_json = attributes.fetch(:json, nil)
+      schema_body = attributes.except(:json, :name)
 
-      FakeSchema.new(name, json_attribute || attributes_as_json)
+      FakeSchema.new(name, schema_body_as_json || schema_body)
     end
 
     after :create do |schema|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
       body { { "id": 1 }.to_json }
     end
 
+    trait :invalid_with_id do
+      body { { "id": "1" }.to_json }
+    end
+
     skip_create
 
     initialize_with do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,35 +1,14 @@
-require "json_matchers/payload"
-
 FactoryBot.define do
-  FakeResponse = Struct.new(:body) do
-    def to_h
-      JSON.parse(body)
-    end
-
-    def to_json
-      body
-    end
-  end
-  FakeSchema = Struct.new(:name, :json) do
-    def to_h
-      json
-    end
-
-    def to_s
-      name
-    end
-  end
-
   factory :response, class: FakeResponse do
-    trait :with_id do
+    skip_create
+
+    trait :object do
       body { { "id": 1 }.to_json }
     end
 
-    trait :invalid_with_id do
+    trait :invalid_object do
       body { { "id": "1" }.to_json }
     end
-
-    skip_create
 
     initialize_with do
       body = attributes.fetch(:body, nil)
@@ -40,13 +19,15 @@ FactoryBot.define do
   end
 
   factory :schema, class: FakeSchema do
+    skip_create
+
     sequence(:name) { |n| "json_schema-#{n}" }
 
     trait :invalid do
       json { "" }
     end
 
-    trait :with_id do
+    trait :object do
       json do
         {
           "type": "object",
@@ -60,9 +41,9 @@ FactoryBot.define do
         }
       end
     end
-    trait(:with_ids) { with_id }
+    trait(:objects) { object }
 
-    trait :array do
+    trait :array_of do
       initialize_with do
         schema_body_as_json = attributes.fetch(:json, nil)
         schema_body = attributes.except(:json, :name)
@@ -73,8 +54,6 @@ FactoryBot.define do
         })
       end
     end
-
-    skip_create
 
     initialize_with do
       schema_body_as_json = attributes.fetch(:json, nil)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,8 +1,16 @@
 require "json_matchers/payload"
 
 FactoryBot.define do
-  FakeResponse = Struct.new(:body)
+  FakeResponse = Struct.new(:body) do
+    def to_h
+      JSON.parse(body)
+    end
+  end
   FakeSchema = Struct.new(:name, :json) do
+    def to_h
+      json
+    end
+
     def to_s
       name
     end

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -101,44 +101,46 @@ describe JsonMatchers, "#match_json_schema" do
     expect(json).not_to match_json_schema(schema)
   end
 
-  it "contains the body in the failure message" do
-    schema = create(:schema, :with_id)
+  describe "the failure message" do
+    it "contains the body" do
+      schema = create(:schema, :with_id)
 
-    json = build(:response, { "id": "1" })
+      json = build(:response, { "id": "1" })
 
-    expect {
-      expect(json).to match_json_schema(schema)
-    }.to raise_error_containing(json)
-  end
+      expect {
+        expect(json).to match_json_schema(schema)
+      }.to raise_error_containing(json)
+    end
 
-  it "contains the body in the failure message when negated" do
-    schema = create(:schema, :with_id)
+    it "contains the schema" do
+      schema = create(:schema, :with_id)
 
-    json = build(:response, { "id": 1 })
+      json = build(:response, { "id": "1" })
 
-    expect {
-      expect(json).not_to match_json_schema(schema)
-    }.to raise_error_containing(json)
-  end
+      expect {
+        expect(json).to match_json_schema(schema)
+      }.to raise_error_containing(schema)
+    end
 
-  it "contains the schema in the failure message" do
-    schema = create(:schema, { "type": "array" })
+    it "when negated, contains the body" do
+      schema = create(:schema, :with_id)
 
-    json = build(:response, { "id": 1 })
+      json = build(:response, { "id": 1 })
 
-    expect {
-      expect(json).to match_json_schema(schema)
-    }.to raise_error_containing(schema)
-  end
+      expect {
+        expect(json).not_to match_json_schema(schema)
+      }.to raise_error_containing(json)
+    end
 
-  it "contains the schema in the failure message when negated" do
-    schema = create(:schema, { "type": "array" })
+    it "when negated, contains the schema" do
+      schema = create(:schema, :with_id)
 
-    json = build(:response, body: "[]")
+      json = build(:response, { "id": 1 })
 
-    expect {
-      expect(json).not_to match_json_schema(schema)
-    }.to raise_error_containing(schema)
+      expect {
+        expect(json).not_to match_json_schema(schema)
+      }.to raise_error_containing(schema)
+    end
   end
 
   it "supports $ref" do

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -20,7 +20,7 @@ describe JsonMatchers, "#match_json_schema" do
   it "fails when the body contains a property with the wrong type" do
     schema = create(:schema, :with_id)
 
-    json = build(:response, { "id": "1" })
+    json = build(:response, :invalid_with_id)
 
     expect(json).not_to match_json_schema(schema)
   end
@@ -45,7 +45,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "fails with message when negated" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, { "id": "1" }).to_h
+      json = build(:response, :invalid_with_id).to_h
 
       expect {
         expect(json).to match_json_schema(schema)
@@ -65,7 +65,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "refutes a root-level Array in the JSON" do
       schema = create(:schema, :array, :with_ids)
 
-      json = build(:response, { "id": "1" }).to_h
+      json = build(:response, :invalid_with_id).to_h
 
       expect([json]).not_to match_json_schema(schema)
     end
@@ -73,7 +73,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "fails with message when negated" do
       schema = create(:schema, :array, :with_id)
 
-      json = build(:response, { "id": "1" }).to_h
+      json = build(:response, :invalid_with_id).to_h
 
       expect {
         expect([json]).to match_json_schema(schema)
@@ -93,7 +93,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "fails with message when negated" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, { "id": "1" }).to_json
+      json = build(:response, :invalid_with_id).to_json
 
       expect {
         expect(json).to match_json_schema(schema)
@@ -105,7 +105,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "contains the body" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, { "id": "1" })
+      json = build(:response, :invalid_with_id)
 
       expect {
         expect(json).to match_json_schema(schema)
@@ -115,7 +115,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "contains the schema" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, { "id": "1" })
+      json = build(:response, :invalid_with_id)
 
       expect {
         expect(json).to match_json_schema(schema)

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -18,12 +18,7 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "fails when the body is missing a required property" do
-    schema = create(:schema, {
-      "type": "object",
-      "required": [
-        "id",
-      ],
-    })
+    schema = create(:schema, :with_id)
 
     json = build(:response, {})
 
@@ -32,16 +27,7 @@ describe JsonMatchers, "#match_json_schema" do
 
   context "when passed a Hash" do
     it "validates when the schema matches" do
-      schema = create(:schema, {
-        "type": "object",
-        "required": [
-          "id",
-        ],
-        "properties": {
-          "id": { "type": "number" },
-        },
-        "additionalProperties": false,
-      })
+      schema = create(:schema, :with_id)
 
       json = { "id": 1 }
 
@@ -49,16 +35,7 @@ describe JsonMatchers, "#match_json_schema" do
     end
 
     it "fails with message when negated" do
-      schema = create(:schema, {
-        "type": "object",
-        "required": [
-          "id",
-        ],
-        "properties": {
-          "id": { "type": "number" },
-        },
-        "additionalProperties": false,
-      })
+      schema = create(:schema, :with_id)
 
       json = { "id": "1" }
 
@@ -69,61 +46,24 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   context "when passed a Array" do
-    it "validates when the schema matches" do
-      schema = create(:schema, {
-        "type": "array",
-        "items": {
-          "required": [
-            "id",
-          ],
-          "properties": {
-            "id": { "type": "number" },
-          },
-          "additionalProperties": false,
-        },
-      })
+    it "validates a root-level Array in the JSON" do
+      schema = create(:schema, :array, :with_ids)
 
       json = [{ "id": 1 }]
 
       expect(json).to match_json_schema(schema)
     end
 
-    it "validates a root-level Array in the JSON" do
-      schema = create(:schema, {
-        "type": "array",
-        "items": { "type": "string" },
-      })
-
-      json = build(:response, body: ["valid"])
-
-      expect(json).to match_json_schema(schema)
-    end
-
     it "refutes a root-level Array in the JSON" do
-      schema = create(:schema, {
-        "type": "array",
-        "items": { "type": "string" },
-      })
+      schema = create(:schema, :array, :with_ids)
 
-      json = build(:response, body: [1])
+      json = build(:response, body: ["invalid"])
 
       expect(json).not_to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
-      schema = create(:schema, {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "required": [
-            "id",
-          ],
-          "properties": {
-            "id": { "type": "number" },
-          },
-          "additionalProperties": false,
-        },
-      })
+      schema = create(:schema, :array, :with_id)
 
       json = [{ "id": "1" }]
 
@@ -135,16 +75,7 @@ describe JsonMatchers, "#match_json_schema" do
 
   context "when JSON is a string" do
     it "validates when the schema matches" do
-      schema = create(:schema, {
-        "type": "object",
-        "required": [
-          "id",
-        ],
-        "properties": {
-          "id": { "type": "number" },
-        },
-        "additionalProperties": false,
-      })
+      schema = create(:schema, :with_id)
 
       json = { "id": 1 }.to_json
 
@@ -152,16 +83,7 @@ describe JsonMatchers, "#match_json_schema" do
     end
 
     it "fails with message when negated" do
-      schema = create(:schema, {
-        "type": "object",
-        "required": [
-          "id",
-        ],
-        "properties": {
-          "id": { "type": "number" },
-        },
-        "additionalProperties": false,
-      })
+      schema = create(:schema, :with_id)
 
       json = { "id": "1" }.to_json
 
@@ -172,15 +94,7 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "fails when the body contains a property with the wrong type" do
-    schema = create(:schema, {
-      "type": "object",
-      "required": [
-        "id",
-      ],
-      "properties": {
-        "id": { "type": "number" },
-      },
-    })
+    schema = create(:schema, :with_id)
 
     json = build(:response, { "id": "1" })
 
@@ -188,15 +102,7 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "contains the body in the failure message" do
-    schema = create(:schema, {
-      "type": "object",
-      "required": [
-        "id",
-      ],
-      "properties": {
-        "id": { "type": "number" },
-      },
-    })
+    schema = create(:schema, :with_id)
 
     json = build(:response, { "id": "1" })
 
@@ -206,15 +112,7 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "contains the body in the failure message when negated" do
-    schema = create(:schema, {
-      "type": "object",
-      "required": [
-        "id",
-      ],
-      "properties": {
-        "id": { "type": "number" },
-      },
-    })
+    schema = create(:schema, :with_id)
 
     json = build(:response, { "id": 1 })
 

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -37,7 +37,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "validates that the schema matches" do
       schema = create(:schema, :with_id)
 
-      json = { "id": 1 }
+      json = build(:response, :with_id).to_h
 
       expect(json).to match_json_schema(schema)
     end
@@ -45,7 +45,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "fails with message when negated" do
       schema = create(:schema, :with_id)
 
-      json = { "id": "1" }
+      json = build(:response, { "id": "1" }).to_h
 
       expect {
         expect(json).to match_json_schema(schema)
@@ -57,26 +57,26 @@ describe JsonMatchers, "#match_json_schema" do
     it "validates a root-level Array in the JSON" do
       schema = create(:schema, :array, :with_ids)
 
-      json = [{ "id": 1 }]
+      json = build(:response, :with_id).to_h
 
-      expect(json).to match_json_schema(schema)
+      expect([json]).to match_json_schema(schema)
     end
 
     it "refutes a root-level Array in the JSON" do
       schema = create(:schema, :array, :with_ids)
 
-      json = build(:response, body: ["invalid"])
+      json = build(:response, { "id": "1" }).to_h
 
-      expect(json).not_to match_json_schema(schema)
+      expect([json]).not_to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
       schema = create(:schema, :array, :with_id)
 
-      json = [{ "id": "1" }]
+      json = build(:response, { "id": "1" }).to_h
 
       expect {
-        expect(json).to match_json_schema(schema)
+        expect([json]).to match_json_schema(schema)
       }.to raise_error_containing(schema)
     end
   end
@@ -85,7 +85,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "validates that the schema matches" do
       schema = create(:schema, :with_id)
 
-      json = { "id": 1 }.to_json
+      json = build(:response, :with_id).to_json
 
       expect(json).to match_json_schema(schema)
     end
@@ -93,7 +93,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "fails with message when negated" do
       schema = create(:schema, :with_id)
 
-      json = { "id": "1" }.to_json
+      json = build(:response, { "id": "1" }).to_json
 
       expect {
         expect(json).to match_json_schema(schema)
@@ -125,7 +125,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "when negated, contains the body" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, { "id": 1 })
+      json = build(:response, :with_id)
 
       expect {
         expect(json).not_to match_json_schema(schema)
@@ -135,7 +135,7 @@ describe JsonMatchers, "#match_json_schema" do
     it "when negated, contains the schema" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, { "id": 1 })
+      json = build(:response, :with_id)
 
       expect {
         expect(json).not_to match_json_schema(schema)
@@ -149,20 +149,20 @@ describe JsonMatchers, "#match_json_schema" do
       "$ref": "#{nested.name}.json",
     })
 
-    valid_response = build(:response, body: [{ "id": 1 }])
-    invalid_response = build(:response, body: [{ "id": "invalid" }])
+    valid_json = build(:response, body: [{ "id": 1 }])
+    invalid_json = build(:response, body: [{ "id": "1" }])
 
-    expect(valid_response).to match_json_schema(collection)
-    expect(valid_response).to match_response_schema(collection)
-    expect(invalid_response).not_to match_json_schema(collection)
-    expect(invalid_response).not_to match_response_schema(collection)
+    expect(valid_json).to match_json_schema(collection)
+    expect(valid_json).to match_response_schema(collection)
+    expect(invalid_json).not_to match_json_schema(collection)
+    expect(invalid_json).not_to match_response_schema(collection)
   end
 
   context "when options are passed directly to the matcher" do
     it "forwards options to the validator" do
       schema = create(:schema, :with_id)
 
-      matching_json = build(:response, { "id": 1 })
+      matching_json = build(:response, :with_id)
       invalid_json = build(:response, { "id": 1, "title": "bar" })
 
       expect(matching_json).to match_json_schema(schema, strict: true)
@@ -175,7 +175,7 @@ describe JsonMatchers, "#match_json_schema" do
       with_options(strict: true) do
         schema = create(:schema, :with_id)
 
-        matching_json = build(:response, { "id": 1 })
+        matching_json = build(:response, :with_id)
         invalid_json = build(:response, { "id": 1, "title": "bar" })
 
         expect(matching_json).to match_json_schema(schema)

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -37,18 +37,20 @@ describe JsonMatchers, "#match_json_schema" do
     it "validates that the schema matches" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, :with_id).to_h
+      json = build(:response, :with_id)
+      json_as_hash = json.to_h
 
-      expect(json).to match_json_schema(schema)
+      expect(json_as_hash).to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, :invalid_with_id).to_h
+      json = build(:response, :invalid_with_id)
+      json_as_hash = json.to_h
 
       expect {
-        expect(json).to match_json_schema(schema)
+        expect(json_as_hash).to match_json_schema(schema)
       }.to raise_error_containing(schema)
     end
   end
@@ -57,26 +59,29 @@ describe JsonMatchers, "#match_json_schema" do
     it "validates a root-level Array in the JSON" do
       schema = create(:schema, :array, :with_ids)
 
-      json = build(:response, :with_id).to_h
+      json = build(:response, :with_id)
+      json_as_array = [json.to_h]
 
-      expect([json]).to match_json_schema(schema)
+      expect(json_as_array).to match_json_schema(schema)
     end
 
     it "refutes a root-level Array in the JSON" do
       schema = create(:schema, :array, :with_ids)
 
-      json = build(:response, :invalid_with_id).to_h
+      json = build(:response, :invalid_with_id)
+      json_as_array = [json.to_h]
 
-      expect([json]).not_to match_json_schema(schema)
+      expect(json_as_array).not_to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
       schema = create(:schema, :array, :with_id)
 
-      json = build(:response, :invalid_with_id).to_h
+      json = build(:response, :invalid_with_id)
+      json_as_array = [json.to_h]
 
       expect {
-        expect([json]).to match_json_schema(schema)
+        expect(json_as_array).to match_json_schema(schema)
       }.to raise_error_containing(schema)
     end
   end
@@ -85,18 +90,20 @@ describe JsonMatchers, "#match_json_schema" do
     it "validates that the schema matches" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, :with_id).to_json
+      json = build(:response, :with_id)
+      json_as_string = json.to_json
 
-      expect(json).to match_json_schema(schema)
+      expect(json_as_string).to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
       schema = create(:schema, :with_id)
 
-      json = build(:response, :invalid_with_id).to_json
+      json = build(:response, :invalid_with_id)
+      json_as_string = json.to_json
 
       expect {
-        expect(json).to match_json_schema(schema)
+        expect(json_as_string).to match_json_schema(schema)
       }.to raise_error_containing(schema)
     end
   end

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -18,15 +18,15 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "fails when the body contains a property with the wrong type" do
-    schema = create(:schema, :with_id)
+    schema = create(:schema, :object)
 
-    json = build(:response, :invalid_with_id)
+    json = build(:response, :invalid_object)
 
     expect(json).not_to match_json_schema(schema)
   end
 
   it "fails when the body is missing a required property" do
-    schema = create(:schema, :with_id)
+    schema = create(:schema, :object)
 
     json = build(:response, {})
 
@@ -35,18 +35,18 @@ describe JsonMatchers, "#match_json_schema" do
 
   context "when passed a Hash" do
     it "validates that the schema matches" do
-      schema = create(:schema, :with_id)
+      schema = create(:schema, :object)
 
-      json = build(:response, :with_id)
+      json = build(:response, :object)
       json_as_hash = json.to_h
 
       expect(json_as_hash).to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
-      schema = create(:schema, :with_id)
+      schema = create(:schema, :object)
 
-      json = build(:response, :invalid_with_id)
+      json = build(:response, :invalid_object)
       json_as_hash = json.to_h
 
       expect {
@@ -57,27 +57,27 @@ describe JsonMatchers, "#match_json_schema" do
 
   context "when passed a Array" do
     it "validates a root-level Array in the JSON" do
-      schema = create(:schema, :array, :with_ids)
+      schema = create(:schema, :array_of, :objects)
 
-      json = build(:response, :with_id)
+      json = build(:response, :object)
       json_as_array = [json.to_h]
 
       expect(json_as_array).to match_json_schema(schema)
     end
 
     it "refutes a root-level Array in the JSON" do
-      schema = create(:schema, :array, :with_ids)
+      schema = create(:schema, :array_of, :objects)
 
-      json = build(:response, :invalid_with_id)
+      json = build(:response, :invalid_object)
       json_as_array = [json.to_h]
 
       expect(json_as_array).not_to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
-      schema = create(:schema, :array, :with_id)
+      schema = create(:schema, :array_of, :object)
 
-      json = build(:response, :invalid_with_id)
+      json = build(:response, :invalid_object)
       json_as_array = [json.to_h]
 
       expect {
@@ -88,18 +88,18 @@ describe JsonMatchers, "#match_json_schema" do
 
   context "when JSON is a string" do
     it "validates that the schema matches" do
-      schema = create(:schema, :with_id)
+      schema = create(:schema, :object)
 
-      json = build(:response, :with_id)
+      json = build(:response, :object)
       json_as_string = json.to_json
 
       expect(json_as_string).to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
-      schema = create(:schema, :with_id)
+      schema = create(:schema, :object)
 
-      json = build(:response, :invalid_with_id)
+      json = build(:response, :invalid_object)
       json_as_string = json.to_json
 
       expect {
@@ -110,9 +110,9 @@ describe JsonMatchers, "#match_json_schema" do
 
   describe "the failure message" do
     it "contains the body" do
-      schema = create(:schema, :with_id)
+      schema = create(:schema, :object)
 
-      json = build(:response, :invalid_with_id)
+      json = build(:response, :invalid_object)
 
       expect {
         expect(json).to match_json_schema(schema)
@@ -120,9 +120,9 @@ describe JsonMatchers, "#match_json_schema" do
     end
 
     it "contains the schema" do
-      schema = create(:schema, :with_id)
+      schema = create(:schema, :object)
 
-      json = build(:response, :invalid_with_id)
+      json = build(:response, :invalid_object)
 
       expect {
         expect(json).to match_json_schema(schema)
@@ -130,9 +130,9 @@ describe JsonMatchers, "#match_json_schema" do
     end
 
     it "when negated, contains the body" do
-      schema = create(:schema, :with_id)
+      schema = create(:schema, :object)
 
-      json = build(:response, :with_id)
+      json = build(:response, :object)
 
       expect {
         expect(json).not_to match_json_schema(schema)
@@ -140,9 +140,9 @@ describe JsonMatchers, "#match_json_schema" do
     end
 
     it "when negated, contains the schema" do
-      schema = create(:schema, :with_id)
+      schema = create(:schema, :object)
 
-      json = build(:response, :with_id)
+      json = build(:response, :object)
 
       expect {
         expect(json).not_to match_json_schema(schema)
@@ -151,8 +151,8 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "supports $ref" do
-    nested = create(:schema, :with_id)
-    collection = create(:schema, :array, {
+    nested = create(:schema, :object)
+    collection = create(:schema, :array_of, {
       "$ref": "#{nested.name}.json",
     })
 
@@ -167,9 +167,9 @@ describe JsonMatchers, "#match_json_schema" do
 
   context "when options are passed directly to the matcher" do
     it "forwards options to the validator" do
-      schema = create(:schema, :with_id)
+      schema = create(:schema, :object)
 
-      matching_json = build(:response, :with_id)
+      matching_json = build(:response, :object)
       invalid_json = build(:response, { "id": 1, "title": "bar" })
 
       expect(matching_json).to match_json_schema(schema, strict: true)
@@ -180,9 +180,9 @@ describe JsonMatchers, "#match_json_schema" do
   context "when options are configured globally" do
     it "forwards them to the validator" do
       with_options(strict: true) do
-        schema = create(:schema, :with_id)
+        schema = create(:schema, :object)
 
-        matching_json = build(:response, :with_id)
+        matching_json = build(:response, :object)
         invalid_json = build(:response, { "id": 1, "title": "bar" })
 
         expect(matching_json).to match_json_schema(schema)
@@ -217,18 +217,11 @@ describe JsonMatchers, "#match_json_schema" do
 
   def raise_error_containing(schema_or_body)
     raise_error do |error|
-      sanitized_message = squish(error.message)
+      sanitized_message = error.message.squish
       json = JSON.pretty_generate(schema_or_body.to_h)
-      error_message = squish(json)
+      error_message = json.squish
 
       expect(sanitized_message).to include(error_message)
     end
-  end
-
-  def squish(string)
-    string.
-      gsub(/\A[[:space:]]+/, "").
-      gsub(/[[:space:]]+\z/, "").
-      gsub(/[[:space:]]+/, " ")
   end
 end

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -17,6 +17,14 @@ describe JsonMatchers, "#match_json_schema" do
     expect(json).to match_json_schema(schema)
   end
 
+  it "fails when the body contains a property with the wrong type" do
+    schema = create(:schema, :with_id)
+
+    json = build(:response, { "id": "1" })
+
+    expect(json).not_to match_json_schema(schema)
+  end
+
   it "fails when the body is missing a required property" do
     schema = create(:schema, :with_id)
 
@@ -26,7 +34,7 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   context "when passed a Hash" do
-    it "validates when the schema matches" do
+    it "validates that the schema matches" do
       schema = create(:schema, :with_id)
 
       json = { "id": 1 }
@@ -74,7 +82,7 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   context "when JSON is a string" do
-    it "validates when the schema matches" do
+    it "validates that the schema matches" do
       schema = create(:schema, :with_id)
 
       json = { "id": 1 }.to_json
@@ -91,14 +99,6 @@ describe JsonMatchers, "#match_json_schema" do
         expect(json).to match_json_schema(schema)
       }.to raise_error_containing(schema)
     end
-  end
-
-  it "fails when the body contains a property with the wrong type" do
-    schema = create(:schema, :with_id)
-
-    json = build(:response, { "id": "1" })
-
-    expect(json).not_to match_json_schema(schema)
   end
 
   describe "the failure message" do
@@ -144,20 +144,13 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "supports $ref" do
-    nested = create(:schema, {
-      "type": "object",
-      "required": ["foo"],
-      "properties": {
-        "foo": { "type": "string" },
-      },
-    })
-    collection = create(:schema, {
-      "type": "array",
-      "items": { "$ref": "#{nested.name}.json" },
+    nested = create(:schema, :with_id)
+    collection = create(:schema, :array, {
+      "$ref": "#{nested.name}.json",
     })
 
-    valid_response = build(:response, body: [{ "foo": "is a string" }])
-    invalid_response = build(:response, body: [{ "foo": 0 }])
+    valid_response = build(:response, body: [{ "id": 1 }])
+    invalid_response = build(:response, body: [{ "id": "invalid" }])
 
     expect(valid_response).to match_json_schema(collection)
     expect(valid_response).to match_response_schema(collection)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "json_matchers/rspec"
+require "active_support/core_ext/string"
 
 Dir["./spec/support/*"].each { |file| require file }
 

--- a/spec/support/fake_response.rb
+++ b/spec/support/fake_response.rb
@@ -1,0 +1,9 @@
+FakeResponse = Struct.new(:body) do
+  def to_h
+    JSON.parse(body)
+  end
+
+  def to_json
+    body
+  end
+end

--- a/spec/support/fake_schema.rb
+++ b/spec/support/fake_schema.rb
@@ -1,0 +1,9 @@
+FakeSchema = Struct.new(:name, :json) do
+  def to_h
+    json
+  end
+
+  def to_s
+    name
+  end
+end


### PR DESCRIPTION
Before adding support for MiniTest (and upgrading to newer versions of JSON Schema support), simplify the test suite's data to limit the amount of duplication necessary to support both libraries.