### PR TITLE
Make test data consistent via factories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,10 @@ Style/BracesAroundHashParameters:
   Enabled: true
   Exclude:
     - 'spec/**/*_spec.rb'
+    - 'spec/support/factories.rb'
 
 Layout/IndentHash:
   Enabled: true
   Exclude:
     - 'spec/**/*_spec.rb'
+    - 'spec/support/factories.rb'

--- a/json_matchers.gemspec
+++ b/json_matchers.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", ">= 2.0"
   spec.add_development_dependency "factory_bot", ">= 4.8"
+  spec.add_development_dependency "activesupport"
 end

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -37,18 +37,20 @@ describe JsonMatchers, "#match_json_schema" do
     it "validates that the schema matches" do
       schema = create(:schema, :object)
 
-      json = build(:response, :object).to_h
+      json = build(:response, :object)
+      json_as_hash = json.to_h
 
-      expect(json).to match_json_schema(schema)
+      expect(json_as_hash).to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
       schema = create(:schema, :object)
 
-      json = build(:response, :invalid_object).to_h
+      json = build(:response, :invalid_object)
+      json_as_hash = json.to_h
 
       expect {
-        expect(json).to match_json_schema(schema)
+        expect(json_as_hash).to match_json_schema(schema)
       }.to raise_error_containing(schema)
     end
   end
@@ -57,26 +59,29 @@ describe JsonMatchers, "#match_json_schema" do
     it "validates a root-level Array in the JSON" do
       schema = create(:schema, :array_of, :objects)
 
-      json = build(:response, :object).to_h
+      json = build(:response, :object)
+      json_as_array = [json.to_h]
 
-      expect([json]).to match_json_schema(schema)
+      expect(json_as_array).to match_json_schema(schema)
     end
 
     it "refutes a root-level Array in the JSON" do
       schema = create(:schema, :array_of, :objects)
 
-      json = build(:response, :invalid_object).to_h
+      json = build(:response, :invalid_object)
+      json_as_array = [json.to_h]
 
-      expect([json]).not_to match_json_schema(schema)
+      expect(json_as_array).not_to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
       schema = create(:schema, :array_of, :object)
 
-      json = build(:response, :invalid_object).to_h
+      json = build(:response, :invalid_object)
+      json_as_array = [json.to_h]
 
       expect {
-        expect([json]).to match_json_schema(schema)
+        expect(json_as_array).to match_json_schema(schema)
       }.to raise_error_containing(schema)
     end
   end
@@ -85,18 +90,20 @@ describe JsonMatchers, "#match_json_schema" do
     it "validates that the schema matches" do
       schema = create(:schema, :object)
 
-      json = build(:response, :object).to_json
+      json = build(:response, :object)
+      json_as_string = json.to_json
 
-      expect(json).to match_json_schema(schema)
+      expect(json_as_string).to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
       schema = create(:schema, :object)
 
-      json = build(:response, :invalid_object).to_json
+      json = build(:response, :invalid_object)
+      json_as_string = json.to_json
 
       expect {
-        expect(json).to match_json_schema(schema)
+        expect(json_as_string).to match_json_schema(schema)
       }.to raise_error_containing(schema)
     end
   end
@@ -109,44 +116,46 @@ describe JsonMatchers, "#match_json_schema" do
     expect(json).not_to match_json_schema(schema)
   end
 
-  it "contains the body in the failure message" do
-    schema = create(:schema, :object)
+  describe "the failure message" do
+    it "contains the body" do
+      schema = create(:schema, :object)
 
-    json = build(:response, :invalid_object)
+      json = build(:response, :invalid_object)
 
-    expect {
-      expect(json).to match_json_schema(schema)
-    }.to raise_error_containing(json)
-  end
+      expect {
+        expect(json).to match_json_schema(schema)
+      }.to raise_error_containing(json)
+    end
 
-  it "contains the body in the failure message when negated" do
-    schema = create(:schema, :object)
+    it "contains the schema" do
+      schema = create(:schema, :object)
 
-    json = build(:response, :object)
+      json = build(:response, :invalid_object)
 
-    expect {
-      expect(json).not_to match_json_schema(schema)
-    }.to raise_error_containing(json)
-  end
+      expect {
+        expect(json).to match_json_schema(schema)
+      }.to raise_error_containing(schema)
+    end
 
-  it "contains the schema in the failure message" do
-    schema = create(:schema, :object)
+    it "when negated, contains the body" do
+      schema = create(:schema, :object)
 
-    json = build(:response, :invalid_object)
+      json = build(:response, :object)
 
-    expect {
-      expect(json).to match_json_schema(schema)
-    }.to raise_error_containing(schema)
-  end
+      expect {
+        expect(json).not_to match_json_schema(schema)
+      }.to raise_error_containing(json)
+    end
 
-  it "contains the schema in the failure message when negated" do
-    schema = create(:schema, { "type": "array" })
+    it "when negated, contains the schema" do
+      schema = create(:schema, :object)
 
-    json = build(:response, body: "[]")
+      json = build(:response, :object)
 
-    expect {
-      expect(json).not_to match_json_schema(schema)
-    }.to raise_error_containing(schema)
+      expect {
+        expect(json).not_to match_json_schema(schema)
+      }.to raise_error_containing(schema)
+    end
   end
 
   it "supports $ref" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "json_matchers/rspec"
+require "active_support/core_ext/string"
 
 Dir["./spec/support/*"].each { |file| require file }
 

--- a/spec/support/fake_response.rb
+++ b/spec/support/fake_response.rb
@@ -1,0 +1,9 @@
+FakeResponse = Struct.new(:body) do
+  def to_h
+    JSON.parse(body)
+  end
+
+  def to_json
+    body
+  end
+end

--- a/spec/support/fake_schema.rb
+++ b/spec/support/fake_schema.rb
@@ -1,0 +1,9 @@
+FakeSchema = Struct.new(:name, :json) do
+  def to_h
+    json
+  end
+
+  def to_s
+    name
+  end
+end


### PR DESCRIPTION
Introduce `object` traits
---

A Schema created by a factory call with the `object` trait will declare
an object that has `{ "id": { "type": "number" } }`.

A Response created by a factory call with the `object` trait will create
an instance that serializes to an array with `{ "id": 1 }`. A
corresponding `invalid_object` trait will build a response that has an
`"id"` key that is not a number.

Additionally, this commit extracts the `FakeResponse` and `FakeSchema`
classes out of the factory file and into files of their own.

Instances of both classes now respond to `#to_h` so that they can be
passed directly to `raise_error_containing`, without any coercion at the
call site.

Instances of `FakeSchema` now respond to `#to_s` so that they can be
passed directly to `match_json_schema`.

`ActiveSupport` is added as a dependency, so that
`raise_error_containing` can invoke `String#squish` to normalize the
serialized exceptions and the messages passed into the expectation.


Group failure message tests
---

Restructure some test blocks to group together tests that assert the
shape and contents of assertive and negated failure messages.

When exercise-level variables are coerced into Strings, Hashes, and
Arrays, separate variables into the factory-built variables, and more
intention-revealing coerced variables.