### PR TITLE
Introduce `referencing_objects` trait

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -55,6 +55,17 @@ FactoryBot.define do
       end
     end
 
+    trait :referencing_objects do
+      association :items, factory: [:schema, :object]
+
+      initialize_with do
+        FakeSchema.new(name, {
+          "type": "array",
+          "items": { "$ref": "#{items.name}.json" },
+        })
+      end
+    end
+
     initialize_with do
       schema_body_as_json = attributes.fetch(:json, nil)
       schema_body = attributes.except(:json, :name)

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -17,6 +17,22 @@ describe JsonMatchers, "#match_json_schema" do
     expect(json).to match_json_schema(schema)
   end
 
+  it "supports asserting with the match_response_schema alias" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :invalid_object)
+
+    expect(json).not_to match_response_schema(schema)
+  end
+
+  it "supports refuting with the match_response_schema alias" do
+    schema = create(:schema, :object)
+
+    json = build(:response, :invalid_object)
+
+    expect(json).not_to match_response_schema(schema)
+  end
+
   it "fails when the body contains a property with the wrong type" do
     schema = create(:schema, :object)
 
@@ -158,19 +174,22 @@ describe JsonMatchers, "#match_json_schema" do
     end
   end
 
-  it "supports $ref" do
-    nested = create(:schema, :object)
-    collection = create(:schema, :array_of, {
-      "$ref": "#{nested.name}.json",
-    })
+  it "validates against a schema that uses $ref" do
+    schema = create(:schema, :referencing_objects)
 
-    valid_json = build(:response, body: [{ "id": 1 }])
-    invalid_json = build(:response, body: [{ "id": "1" }])
+    json = build(:response, :object)
+    json_as_array = [json.to_h]
 
-    expect(valid_json).to match_json_schema(collection)
-    expect(valid_json).to match_response_schema(collection)
-    expect(invalid_json).not_to match_json_schema(collection)
-    expect(invalid_json).not_to match_response_schema(collection)
+    expect(json_as_array).to match_json_schema(schema)
+  end
+
+  it "fails against a schema that uses $ref" do
+    schema = create(:schema, :referencing_objects)
+
+    json = build(:response, :invalid_object)
+    json_as_array = [json.to_h]
+
+    expect(json_as_array).not_to match_json_schema(schema)
   end
 
   context "when options are passed directly to the matcher" do


### PR DESCRIPTION
The `"supports $ref"` test used to contain:

* expectations that the matcher validates valid JSON
* expectations that the matcher rejects invalid JSON
* expectations that both the `match_json_schema` and
  `match_response_schema` matchers were supported

Originally, the test was overloaded with assertions because constructing
a schema referencing another schema _and_ the referenced schema was
tedious and noisy.

With the adoption of using factories, this is no longer the case.

This commit splits out those concerns across multiple tests.