### PR TITLE
[Rubocop]: Fix incorrect path to factories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,10 +10,13 @@ Style/BracesAroundHashParameters:
   Enabled: true
   Exclude:
     - 'spec/**/*_spec.rb'
-    - 'spec/support/factories.rb'
+    - 'spec/factories.rb'
+
+Style/SymbolArray:
+  Enabled: false
 
 Layout/IndentHash:
   Enabled: true
   Exclude:
     - 'spec/**/*_spec.rb'
-    - 'spec/support/factories.rb'
+    - 'spec/factories.rb'


### PR DESCRIPTION
Rubocop was incorrectly configured to exclude the factories from certain
hash style guidelines.

This commit changes `spec/support/factories.rb` references to
`spec/factories.rb`.