### PR TITLE
Rename factories to location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ language: ruby
 notifications:
   email: false
 rvm:
-- 2.5.0
+  - 2.5.0
+before_install:
+  - gem update --system

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,12 +6,12 @@ FactoryBot.define do
   factory :response, class: FakeResponse do
     skip_create
 
-    trait :object do
-      body { { "id": 1 } }
+    trait :location do
+      body { { "latitude": 1, "longitude": 1 } }
     end
 
-    trait :invalid_object do
-      body { { "id": "1" } }
+    trait :invalid_location do
+      body { { "latitude": "1", "longitude": "1" } }
     end
 
     initialize_with do
@@ -30,21 +30,26 @@ FactoryBot.define do
       json { "" }
     end
 
-    trait :object do
+    trait :location do
       json do
         {
           "id": "file:/#{name}.json#",
           "description": "An object containing some #{name} data",
           "type": "object",
-          "required": ["id"],
+          "required": ["latitude", "longitude"],
           "properties": {
-            "id": { "type": "integer" },
+            "latitude": {
+              "type": "number",
+            },
+            "longitude": {
+              "type": "number",
+            },
           },
           "additionalProperties": false,
         }
       end
     end
-    trait(:objects) { object }
+    trait(:locations) { location }
 
     trait :array_of do
       initialize_with do
@@ -58,8 +63,8 @@ FactoryBot.define do
       end
     end
 
-    trait :referencing_objects do
-      association :items, factory: [:schema, :object]
+    trait :referencing_locations do
+      association :items, factory: [:schema, :location]
 
       initialize_with do
         FakeSchema.new(name, {
@@ -71,8 +76,8 @@ FactoryBot.define do
     end
 
     trait :referencing_definitions do
-      association :items, factory: [:schema, :object], name: "object"
-      association :example, factory: [:response, :object]
+      association :items, factory: [:schema, :location], name: "location"
+      association :example, factory: [:response, :location]
 
       transient do
         plural { items.name.pluralize }

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -20,31 +20,31 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "supports asserting with the match_response_schema alias" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
 
     expect(json).not_to match_response_schema(schema)
   end
 
   it "supports refuting with the match_response_schema alias" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
 
     expect(json).not_to match_response_schema(schema)
   end
 
   it "fails when the body contains a property with the wrong type" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
 
     expect(json).not_to match_json_schema(schema)
   end
 
   it "fails when the body is missing a required property" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
     json = build(:response, {})
 
@@ -52,27 +52,27 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "can reference a schema in a directory" do
-    create(:schema, :object, name: "api/v1/schema")
+    create(:schema, :location, name: "api/v1/schema")
 
-    json = build(:response, :object)
+    json = build(:response, :location)
 
     expect(json).to match_json_schema("api/v1/schema")
   end
 
   context "when passed a Hash" do
     it "validates that the schema matches" do
-      schema = create(:schema, :object)
+      schema = create(:schema, :location)
 
-      json = build(:response, :object)
+      json = build(:response, :location)
       json_as_hash = json.to_h
 
       expect(json_as_hash).to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
-      schema = create(:schema, :object)
+      schema = create(:schema, :location)
 
-      json = build(:response, :invalid_object)
+      json = build(:response, :invalid_location)
       json_as_hash = json.to_h
 
       expect {
@@ -83,27 +83,27 @@ describe JsonMatchers, "#match_json_schema" do
 
   context "when passed a Array" do
     it "validates a root-level Array in the JSON" do
-      schema = create(:schema, :array_of, :objects)
+      schema = create(:schema, :array_of, :locations)
 
-      json = build(:response, :object)
+      json = build(:response, :location)
       json_as_array = [json.to_h]
 
       expect(json_as_array).to match_json_schema(schema)
     end
 
     it "refutes a root-level Array in the JSON" do
-      schema = create(:schema, :array_of, :objects)
+      schema = create(:schema, :array_of, :locations)
 
-      json = build(:response, :invalid_object)
+      json = build(:response, :invalid_location)
       json_as_array = [json.to_h]
 
       expect(json_as_array).not_to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
-      schema = create(:schema, :array_of, :object)
+      schema = create(:schema, :array_of, :location)
 
-      json = build(:response, :invalid_object)
+      json = build(:response, :invalid_location)
       json_as_array = [json.to_h]
 
       expect {
@@ -114,18 +114,18 @@ describe JsonMatchers, "#match_json_schema" do
 
   context "when JSON is a string" do
     it "validates that the schema matches" do
-      schema = create(:schema, :object)
+      schema = create(:schema, :location)
 
-      json = build(:response, :object)
+      json = build(:response, :location)
       json_as_string = json.to_json
 
       expect(json_as_string).to match_json_schema(schema)
     end
 
     it "fails with message when negated" do
-      schema = create(:schema, :object)
+      schema = create(:schema, :location)
 
-      json = build(:response, :invalid_object)
+      json = build(:response, :invalid_location)
       json_as_string = json.to_json
 
       expect {
@@ -135,18 +135,18 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "fails when the body contains a property with the wrong type" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
 
     expect(json).not_to match_json_schema(schema)
   end
 
   describe "the failure message" do
     it "contains the body" do
-      schema = create(:schema, :object)
+      schema = create(:schema, :location)
 
-      json = build(:response, :invalid_object)
+      json = build(:response, :invalid_location)
 
       expect {
         expect(json).to match_json_schema(schema)
@@ -154,9 +154,9 @@ describe JsonMatchers, "#match_json_schema" do
     end
 
     it "contains the schema" do
-      schema = create(:schema, :object)
+      schema = create(:schema, :location)
 
-      json = build(:response, :invalid_object)
+      json = build(:response, :invalid_location)
 
       expect {
         expect(json).to match_json_schema(schema)
@@ -164,9 +164,9 @@ describe JsonMatchers, "#match_json_schema" do
     end
 
     it "when negated, contains the body" do
-      schema = create(:schema, :object)
+      schema = create(:schema, :location)
 
-      json = build(:response, :object)
+      json = build(:response, :location)
 
       expect {
         expect(json).not_to match_json_schema(schema)
@@ -174,9 +174,9 @@ describe JsonMatchers, "#match_json_schema" do
     end
 
     it "when negated, contains the schema" do
-      schema = create(:schema, :object)
+      schema = create(:schema, :location)
 
-      json = build(:response, :object)
+      json = build(:response, :location)
 
       expect {
         expect(json).not_to match_json_schema(schema)
@@ -185,18 +185,18 @@ describe JsonMatchers, "#match_json_schema" do
   end
 
   it "validates against a schema that uses $ref" do
-    schema = create(:schema, :referencing_objects)
+    schema = create(:schema, :referencing_locations)
 
-    json = build(:response, :object)
+    json = build(:response, :location)
     json_as_array = [json.to_h]
 
     expect(json_as_array).to match_json_schema(schema)
   end
 
   it "fails against a schema that uses $ref" do
-    schema = create(:schema, :referencing_objects)
+    schema = create(:schema, :referencing_locations)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
     json_as_array = [json.to_h]
 
     expect(json_as_array).not_to match_json_schema(schema)
@@ -205,8 +205,8 @@ describe JsonMatchers, "#match_json_schema" do
   it "validates against a schema referencing with 'definitions'" do
     schema = create(:schema, :referencing_definitions)
 
-    json = build(:response, :object)
-    json_as_hash = { "objects" => [json] }
+    json = build(:response, :location)
+    json_as_hash = { "locations" => [json] }
 
     expect(json_as_hash).to match_json_schema(schema)
   end
@@ -214,8 +214,8 @@ describe JsonMatchers, "#match_json_schema" do
   it "fails against a schema referencing with 'definitions'" do
     schema = create(:schema, :referencing_definitions)
 
-    json = build(:response, :invalid_object)
-    json_as_hash = { "objects" => [json] }
+    json = build(:response, :invalid_location)
+    json_as_hash = { "locations" => [json] }
 
     expect(json_as_hash).not_to match_json_schema(schema)
   end

--- a/test/json_matchers/minitest/assertions_test.rb
+++ b/test/json_matchers/minitest/assertions_test.rb
@@ -21,15 +21,15 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   end
 
   test "fails when the body contains a property with the wrong type" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
 
     refute_matches_json_schema(json, schema)
   end
 
   test "fails when the body is missing a required property" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
     json = build(:response, {})
 
@@ -37,26 +37,26 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   end
 
   test "can reference a schema in a directory" do
-    create(:schema, :object, name: "api/v1/schema")
+    create(:schema, :location, name: "api/v1/schema")
 
-    json = build(:response, :object)
+    json = build(:response, :location)
 
     assert_matches_json_schema(json, "api/v1/schema")
   end
 
   test "when passed a Hash, validates that the schema matches" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :object)
+    json = build(:response, :location)
     json_as_hash = json.to_h
 
     assert_matches_json_schema(json_as_hash, schema)
   end
 
   test "when passed a Hash, fails with message when negated" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
     json_as_hash = json.to_h
 
     assert_raises_error_containing(schema) do
@@ -65,27 +65,27 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   end
 
   test "when passed a Array, validates a root-level Array in the JSON" do
-    schema = create(:schema, :array_of, :objects)
+    schema = create(:schema, :array_of, :locations)
 
-    json = build(:response, :object)
+    json = build(:response, :location)
     json_as_array = [json.to_h]
 
     assert_matches_json_schema(json_as_array, schema)
   end
 
   test "when passed a Array, refutes a root-level Array in the JSON" do
-    schema = create(:schema, :array_of, :objects)
+    schema = create(:schema, :array_of, :locations)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
     json_as_array = [json.to_h]
 
     refute_matches_json_schema(json_as_array, schema)
   end
 
   test "when passed a Array, fails with message when negated" do
-    schema = create(:schema, :array_of, :object)
+    schema = create(:schema, :array_of, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
     json_as_array = [json.to_h]
 
     assert_raises_error_containing(schema) do
@@ -94,18 +94,18 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   end
 
   test "when JSON is a string, validates that the schema matches" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :object)
+    json = build(:response, :location)
     json_as_string = json.to_json
 
     assert_matches_json_schema(json_as_string, schema)
   end
 
   test "when JSON is a string, fails with message when negated" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
     json_as_string = json.to_json
 
     assert_raises_error_containing(schema) do
@@ -114,9 +114,9 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   end
 
   test "the failure message contains the body" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
 
     assert_raises_error_containing(json) do
       assert_matches_json_schema(json, schema)
@@ -124,9 +124,9 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   end
 
   test "the failure message contains the schema" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
 
     assert_raises_error_containing(schema) do
       assert_matches_json_schema(json, schema)
@@ -134,9 +134,9 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   end
 
   test "the failure message when negated, contains the body" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :object)
+    json = build(:response, :location)
 
     assert_raises_error_containing(json) do
       refute_matches_json_schema(json, schema)
@@ -144,9 +144,9 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   end
 
   test "the failure message when negated, contains the schema" do
-    schema = create(:schema, :object)
+    schema = create(:schema, :location)
 
-    json = build(:response, :object)
+    json = build(:response, :location)
 
     assert_raises_error_containing(schema) do
       refute_matches_json_schema(json, schema)
@@ -154,18 +154,18 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   end
 
   test "asserts valid JSON against a schema that uses $ref" do
-    schema = create(:schema, :referencing_objects)
+    schema = create(:schema, :referencing_locations)
 
-    json = build(:response, :object)
+    json = build(:response, :location)
     json_as_array = [json.to_h]
 
     assert_matches_json_schema(json_as_array, schema)
   end
 
   test "refutes valid JSON against a schema that uses $ref" do
-    schema = create(:schema, :referencing_objects)
+    schema = create(:schema, :referencing_locations)
 
-    json = build(:response, :invalid_object)
+    json = build(:response, :invalid_location)
     json_as_array = [json.to_h]
 
     refute_matches_json_schema(json_as_array, schema)
@@ -174,8 +174,8 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   test "validates against a schema referencing with 'definitions'" do
     schema = create(:schema, :referencing_definitions)
 
-    json = build(:response, :object)
-    json_as_hash = { "objects" => [json] }
+    json = build(:response, :location)
+    json_as_hash = { "locations" => [json] }
 
     assert_matches_json_schema(json_as_hash, schema)
   end
@@ -183,8 +183,8 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
   test "fails against a schema referencing with 'definitions'" do
     schema = create(:schema, :referencing_definitions)
 
-    json = build(:response, :invalid_object)
-    json_as_hash = { "objects" => [json] }
+    json = build(:response, :invalid_location)
+    json_as_hash = { "locations" => [json] }
 
     refute_matches_json_schema(json_as_hash, schema)
   end


### PR DESCRIPTION
The `object` trait is too generic of a word to discuss unambiguously.

For example, JSON Schema supports `{ "type": "object" }` declarations,
and JSON "hashes" are "objects" as well.

The README currently uses latitude and longitude as an example.

This commit modifies the factories to build latitude-longitude pairs
instead of objects with `id` values.

Co-authored-by: Sean Doyle <sean.p.doyle24@gmail.com>
Co-authored-by: Daniel Colson <danieljamescolson@gmail.com>