### PR TITLE
Add tests covering naming a schema in a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ directory.
 
 #### RSpec
 
-```ruby
-
 Validate a JSON response, a Hash, or a String against a JSON Schema with
 `match_json_schema`:
 
@@ -177,6 +175,43 @@ To learn more about `$ref`, check out
 [Understanding JSON Schema Structuring][$ref].
 
 [$ref]: https://spacetelescope.github.io/understanding-json-schema/structuring.html
+
+### Declaring a schema in a Subdirectory
+
+Nesting a schema within a subdirectory is also supported:
+
+`spec/support/api/schemas/api/v1/location.json`:
+
+
+```json
+{
+  "id": "https://json-schema.org/geo",
+  "$schema": "https://json-schema.org/draft-06/schema#",
+  "description": "A geographical coordinate",
+  "type": "object",
+  "properties": {
+    "latitude": {
+      "type": "number"
+    },
+    "longitude": {
+      "type": "number"
+    }
+  }
+}
+```
+
+`spec/requests/api/v1/locations_spec.rb`:
+
+```ruby
+describe "GET api/v1/locations" do
+  it "returns Locations" do
+    get locations_path, format: :json
+
+    expect(response.status).to eq 200
+    expect(response).to match_json_schema("api/v1/location")
+  end
+end
+```
 
 ## Configuration
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,9 +111,10 @@ FactoryBot.define do
     end
 
     after :create do |schema|
-      path = File.join(JsonMatchers.schema_root, "#{schema.name}.json")
+      path = JsonMatchers.path_to_schema(schema.name)
       payload = JsonMatchers::Payload.new(schema.json)
 
+      path.dirname.mkpath
       IO.write(path, payload)
     end
   end

--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -51,6 +51,14 @@ describe JsonMatchers, "#match_json_schema" do
     expect(json).not_to match_json_schema(schema)
   end
 
+  it "can reference a schema in a directory" do
+    create(:schema, :object, name: "api/v1/schema")
+
+    json = build(:response, :object)
+
+    expect(json).to match_json_schema("api/v1/schema")
+  end
+
   context "when passed a Hash" do
     it "validates that the schema matches" do
       schema = create(:schema, :object)

--- a/test/json_matchers/minitest/assertions_test.rb
+++ b/test/json_matchers/minitest/assertions_test.rb
@@ -36,6 +36,14 @@ class AssertResponseMatchesSchemaTest < JsonMatchers::TestCase
     refute_matches_json_schema(json, schema)
   end
 
+  test "can reference a schema in a directory" do
+    create(:schema, :object, name: "api/v1/schema")
+
+    json = build(:response, :object)
+
+    assert_matches_json_schema(json, "api/v1/schema")
+  end
+
   test "when passed a Hash, validates that the schema matches" do
     schema = create(:schema, :object)
 


### PR DESCRIPTION
Closes [#83][]

Specifying a schema within a directory has always been supported, but
was not covered by the test suite.

This commit adds coverage, along with a corresponding section to the
README.

[#83]: https://github.com/thoughtbot/json_matchers/issues/83