### PR TITLE
Add coverage for JSON Schema V4

### DIFF
--- a/spec/json_matchers/match_json_schema_spec.rb
+++ b/spec/json_matchers/match_json_schema_spec.rb
@@ -59,6 +59,147 @@ describe JsonMatchers, "#match_json_schema" do
     expect(json).to match_json_schema("api/v1/schema")
   end
 
+  it "supports invalidating the referenced schema when using local references" do
+    create(:schema, name: "post", json: {
+      "$schema": "https://json-schema.org/draft-04/schema#",
+      "id": "file:/post.json#",
+      "definitions": {
+        "attributes": {
+          "type": "object",
+          "required": [
+            "id",
+            "name",
+          ],
+          "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "type": "string" },
+        "attributes": {
+          "$ref": "#/definitions/attributes",
+        }
+      }
+    })
+    posts_index = create(:schema, name: "posts/index", json: {
+      "$schema": "https://json-schema.org/draft-04/schema#",
+      "id": "file:/posts/index.json#",
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "definitions": {
+        "posts": {
+          "type": "array",
+          "items": {
+            "$ref": "file:/post.json#"
+          }
+        }
+      },
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/posts"
+        }
+      }
+    })
+
+    json = build(:response, {
+      "data": [{
+        "id": "1",
+        "type": "Post",
+        "attributes": {
+          "id": 1,
+          "name": "The Post's Name"
+        }
+      }]
+    })
+
+    expect(json).not_to match_json_schema(posts_index)
+  end
+
+  it "can reference a schema relatively" do
+    create(:schema, name: "post", json: {
+      "$schema": "https://json-schema.org/draft-04/schema#",
+      "id": "file:/post.json#",
+      "type": "object",
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ],
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "type": "string" },
+        "attributes": {
+          "type": "object",
+          "required": [
+            "id",
+            "name"
+          ],
+          "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "user": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    })
+    posts_index = create(:schema, name: "posts/index", json: {
+      "$schema": "https://json-schema.org/draft-04/schema#",
+      "id": "file:/posts/index.json#",
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "definitions": {
+        "posts": {
+          "type": "array",
+          "items": {
+            "$ref": "file:/post.json#"
+          }
+        }
+      },
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/posts"
+        }
+      }
+    })
+
+    json = build(:response, {
+      "data": [{
+        "id": "1",
+        "type": "Post",
+        "attributes": {
+          "id": "1",
+          "name": "The Post's Name",
+          "user": {
+            "id": "1"
+          }
+        }
+      }]
+    })
+
+    expect(json).to match_json_schema(posts_index)
+  end
+
   context "when passed a Hash" do
     it "validates that the schema matches" do
       schema = create(:schema, :location)


### PR DESCRIPTION
Closes [#88].
Closes [#90].
    
Add tests from Issue #90
    
When the `"id"` key is specified as a `"number"` in both attribute and
property definitions, then specified as a `"string"` value in the
payload, the matcher will raise and the test will pass.
    
After rebasing off `master` after [`3b66b4d`][3b66b4d] was merged, [the
tests that were once failing][tests] are now passing.
    
[#88]: https://github.com/thoughtbot/json_matchers/issues/88
[#90]: https://github.com/thoughtbot/json_matchers/issues/90
[3b66b4d]: https://github.com/thoughtbot/json_matchers/commit/3b66b4ddf369ec09b50cfe39c614266b34c7f3fe
[tests]: https://github.com/thoughtbot/json_matchers/pull/89#issuecomment-437484000