### PR TITLE
Invoke `Module#include` directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ require "json_matchers/minitest/assertions"
 
 JsonMatchers.schema_root = "test/support/api/schemas"
 
-Minitest::Test.send(:include, JsonMatchers::Minitest::Assertions)
+Minitest::Test.include(JsonMatchers::Minitest::Assertions)
 ```
 
 ### Declare

--- a/test/support/factory_bot.rb
+++ b/test/support/factory_bot.rb
@@ -2,4 +2,4 @@ require "factory_bot"
 
 FactoryBot.find_definitions
 
-Minitest::Test.send(:include, FactoryBot::Syntax::Methods)
+Minitest::Test.include(FactoryBot::Syntax::Methods)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,6 @@ require "json_matchers/minitest/assertions"
 
 JsonMatchers.schema_root = "/test/support/api/schemas"
 
-Minitest::Test.send(:include, JsonMatchers::Minitest::Assertions)
+Minitest::Test.include(JsonMatchers::Minitest::Assertions)
 
 Dir["./test/support/**/*.rb"].each { |file| require file }


### PR DESCRIPTION
`Module#include` and `Module#prepend` were made public as of Ruby 2.1 and since
support for Ruby 2.1 has ended we can assume json_matchers does not support
Ruby versions <= 2.1.

See https://github.com/ruby/ruby/blob/v2_1_0/NEWS
See https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended

This change also ensure that the code won't trigger Rubocop-violations due to the following rules:

- https://github.com/rubocop-hq/ruby-style-guide#prefer-public-send
- https://github.com/rubocop-hq/ruby-style-guide#prefer-__send__