### PR TITLE
Configure RuboCop to allow pasting JSON in tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,20 @@ Style/BracesAroundHashParameters:
 Style/SymbolArray:
   Enabled: false
 
+Style/TrailingCommaInArrayLiteral:
+  Enabled: true
+  Exclude:
+    - 'test/**/*_test.rb'
+    - 'spec/**/*_spec.rb'
+    - 'spec/factories.rb'
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: true
+  Exclude:
+    - 'test/**/*_test.rb'
+    - 'spec/**/*_spec.rb'
+    - 'spec/factories.rb'
+
 Layout/IndentHeredoc:
   Enabled: false
 


### PR DESCRIPTION
In order to support the transposition of JSON Schema declarations into
the test suite as fixture data, This commit configures RuboCop to ignore
the omission of trailing Hash and Array commas in `test/` and `spec/`
files.