### PR TITLE
Follow first-level symlinks.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 master
 ======
 
+* Follow first-level symlinks in the document store. [#99]
+
 0.11.0
 ======
 

--- a/lib/json_matchers/matcher.rb
+++ b/lib/json_matchers/matcher.rb
@@ -31,13 +31,19 @@ module JsonMatchers
     def build_and_populate_document_store
       document_store = JsonSchema::DocumentStore.new
 
-      Dir.glob("#{JsonMatchers.schema_root}/**/*.json").
+      traverse_schema_root_with_first_level_symlinks.
         map { |path| Pathname.new(path) }.
         map { |schema_path| Parser.new(schema_path).parse }.
         map { |schema| document_store.add_schema(schema) }.
         each { |schema| schema.expand_references!(store: document_store) }
 
       document_store
+    end
+
+    def traverse_schema_root_with_first_level_symlinks
+      # follow one symlink and direct children
+      # http://stackoverflow.com/questions/357754/can-i-traverse-symlinked-directories-in-ruby-with-a-glob
+      Dir.glob("#{JsonMatchers.schema_root}/**{,/*/**}/*.json")
     end
   end
 end


### PR DESCRIPTION
Hello thoughtbot team,

in a project using json_matcher we wanted to be able to symlink a directory into the `JsonMatcher.schema_root`, unfortunately the `Matcher.build_and_populate_document_store` method uses a glob pattern that doesn't follow symlinks. Might be a bit of an edge case, but allowing to traverse first-level symlinks is relatively trivial.

However, testing is not, or at least the factory-based test setup makes it a bit harder, in my eyes. So if you say this change is worth it, I would come up with a test for it, maybe with a little hint on how to put a symlinked path into the factories. Or maybe you say this doesn't need a test? :)

cheers,
malte